### PR TITLE
Improve AST export in scan_templates

### DIFF
--- a/porter/scan_templates.py
+++ b/porter/scan_templates.py
@@ -2,7 +2,7 @@
 """Scan Eigen headers and build mapping of template instantiations.
 
 This script walks the Eigen/ directory, parses each header with clang's
-Python bindings, dumps the AST to porter/asts/<file>.ast, and records
+Python bindings, dumps the AST to porter/asts/<file>.yaml, and records
 any ClassTemplateDecl or FunctionTemplateDecl names.
 
 It outputs a YAML mapping file mapping template names to placeholder C
@@ -11,8 +11,22 @@ families which can be filled in later.
 
 import os
 import sys
-import yaml
-from clang.cindex import Index, Config, CursorKind
+
+try:
+    import yaml
+
+    HAVE_YAML = True
+except Exception:  # pragma: no cover - optional dependency
+    import json
+
+    HAVE_YAML = False
+
+try:
+    from clang.cindex import Index, Config, CursorKind
+except Exception as exc:  # pragma: no cover - better error message
+    raise SystemExit(
+        "clang Python bindings not found; run setup.sh to install them"
+    ) from exc
 
 # Allow overriding libclang path via env var
 LIBCLANG_PATH = os.environ.get("LIBCLANG_PATH")
@@ -28,12 +42,23 @@ os.makedirs(AST_DIR, exist_ok=True)
 
 index = Index.create()
 
+
+def cursor_to_dict(cursor):
+    """Recursively convert a clang cursor to a serialisable dictionary."""
+    return {
+        "kind": str(cursor.kind),
+        "spelling": cursor.spelling,
+        "children": [cursor_to_dict(c) for c in cursor.get_children()],
+    }
+
+
 def process_header(path: str, tu):
     mapping = {}
     for cursor in tu.cursor.get_children():
         if cursor.kind in (CursorKind.CLASS_TEMPLATE, CursorKind.FUNCTION_TEMPLATE):
             mapping[cursor.spelling] = "TODO"
     return mapping
+
 
 def main():
     compile_args = ["-std=c++17", f"-I{EIGEN_DIR}"]
@@ -50,13 +75,22 @@ def main():
             except Exception as exc:
                 print(f"Failed to parse {path}: {exc}", file=sys.stderr)
                 continue
-            ast_path = os.path.join(AST_DIR, rel_path.replace(os.sep, "_") + ".ast")
+            ext = ".yaml" if HAVE_YAML else ".json"
+            ast_path = os.path.join(AST_DIR, rel_path.replace(os.sep, "_") + ext)
             with open(ast_path, "w", encoding="utf-8") as f:
-                f.write(tu.cursor.get_children().__repr__())
+                data = cursor_to_dict(tu.cursor)
+                if HAVE_YAML:
+                    yaml.dump(data, f)
+                else:
+                    json.dump(data, f, indent=2)
             mapping.update(process_header(path, tu))
 
     with open(MAPPING_PATH, "w", encoding="utf-8") as f:
-        yaml.dump({"mappings": mapping}, f)
+        if HAVE_YAML:
+            yaml.dump({"mappings": mapping}, f)
+        else:
+            json.dump({"mappings": mapping}, f, indent=2)
+
 
 if __name__ == "__main__":
     main()

--- a/setup.sh
+++ b/setup.sh
@@ -18,7 +18,12 @@ apt-get install -y --no-install-recommends \
     curl=7.*
 
 # Python packages
-python3 -m pip install --no-cache-dir numpy==1.26.* pytest==7.* pycparser==2.* clang==17.*
+python3 -m pip install --no-cache-dir \
+    numpy==1.26.* \
+    pytest==7.* \
+    pycparser==2.* \
+    clang==17.* \
+    pyyaml==6.*
 
 # Optional local OpenBLAS debs if provided
 if ls ./vendor/libopenblas*.deb >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- handle optional PyYAML in `scan_templates.py`
- emit JSON when YAML isn't available
- install PyYAML via pip in `setup.sh`

## Testing
- `python3 -m py_compile porter/scan_templates.py`
- `black porter/scan_templates.py --check`
- `python3 porter/scan_templates.py` *(fails: clang Python bindings not found)*
