### PR TITLE
Add dimension asserts in addition ops

### DIFF
--- a/eigenc/include/ec_core.h
+++ b/eigenc/include/ec_core.h
@@ -1,6 +1,7 @@
 #ifndef EC_CORE_H
 #define EC_CORE_H
 #include <stddef.h>
+#include <assert.h>
 
 typedef struct {
     size_t rows;
@@ -15,11 +16,15 @@ typedef struct {
 } ec_Matrixf64;
 
 static inline void ec_addf32(const ec_Matrixf32 *a, const ec_Matrixf32 *b, ec_Matrixf32 *out) {
+    assert(a->rows == b->rows && a->cols == b->cols &&
+           a->rows == out->rows && a->cols == out->cols);
     for (size_t i = 0; i < a->rows * a->cols; ++i)
         out->data[i] = a->data[i] + b->data[i];
 }
 
 static inline void ec_addf64(const ec_Matrixf64 *a, const ec_Matrixf64 *b, ec_Matrixf64 *out) {
+    assert(a->rows == b->rows && a->cols == b->cols &&
+           a->rows == out->rows && a->cols == out->cols);
     for (size_t i = 0; i < a->rows * a->cols; ++i)
         out->data[i] = a->data[i] + b->data[i];
 }


### PR DESCRIPTION
## Summary
- ensure matrix dimensions match for `ec_addf32` and `ec_addf64`
- include `<assert.h>` for new checks

## Testing
- `tests/run_all.sh`