### PR TITLE
Fix c23 flag for tests

### DIFF
--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.."; pwd)"
 
-gcc -std=c2x -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.c" -o /tmp/ec_test
+gcc -std=c23 -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.c" -o /tmp/ec_test \
+  || gcc -std=c2x -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.c" -o /tmp/ec_test
 
 g++ -std=c++17 -I"${ROOT_DIR}" "${ROOT_DIR}/tests/core/test_core.cpp" -o /tmp/eigen_test
 


### PR DESCRIPTION
## Summary
- update gcc invocation in run_all.sh to use `-std=c23`
- fallback to `-std=c2x` when c23 isn't supported

## Testing
- `bash tests/run_all.sh`