### PR TITLE
Add cross-compilation test

### DIFF
--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.."; pwd)"
 
+# Native build
+
 gcc -std=c23 -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.c" -o /tmp/ec_test \
   || gcc -std=c2x -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.c" -o /tmp/ec_test
 
@@ -11,5 +13,26 @@ g++ -std=c++17 -I"${ROOT_DIR}" "${ROOT_DIR}/tests/core/test_core.cpp" -o /tmp/ei
 /tmp/eigen_test
 
 python3 "${ROOT_DIR}/tests/compare_eigen_cpp_vs_c.py"
+cp /tmp/c_out.txt /tmp/c_out_host.txt
 
-echo "\xe2\x9c\x93  all EigenC vs Eigen checks passed"
+echo "\xE2\x9C\x93  native EigenC vs Eigen checks passed"
+
+# Cross-compile for PowerPC and run via qemu
+if ! command -v powerpc-linux-gnu-gcc >/dev/null; then
+  echo "powerpc-linux-gnu-gcc not found" >&2
+  exit 1
+fi
+if ! command -v qemu-ppc-static >/dev/null; then
+  echo "qemu-ppc-static not found" >&2
+  exit 1
+fi
+
+powerpc-linux-gnu-gcc -static -std=c23 -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.c" -o /tmp/ec_test_ppc \
+  || powerpc-linux-gnu-gcc -static -std=c2x -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.c" -o /tmp/ec_test_ppc
+
+qemu-ppc-static /tmp/ec_test_ppc
+mv /tmp/c_out.txt /tmp/c_out_ppc.txt
+
+diff -u /tmp/c_out_host.txt /tmp/c_out_ppc.txt
+
+echo "\xE2\x9C\x93  cross-compiled EigenC checks passed (powerpc)"


### PR DESCRIPTION
## Summary
- expand `tests/run_all.sh` to build for native and powerpc
- run powerpc binary under qemu and compare results

## Testing
- `tests/run_all.sh` *(fails: `powerpc-linux-gnu-gcc not found`)*