### PR TITLE
Add Go bindings for EigenC functions

### DIFF
--- a/go/ec/ec.go
+++ b/go/ec/ec.go
@@ -1,0 +1,104 @@
+package ec
+
+/*
+#cgo CFLAGS: -std=c11 -I${SRCDIR}/../../eigenc/include
+#include "ec_core.h"
+*/
+import "C"
+import "unsafe"
+
+// MatrixF32 mirrors the C ec_Matrixf32 structure.
+type MatrixF32 struct {
+	Rows int
+	Cols int
+	Data []float32
+}
+
+// MatrixF64 mirrors the C ec_Matrixf64 structure.
+type MatrixF64 struct {
+	Rows int
+	Cols int
+	Data []float64
+}
+
+func cMatrixF32(data *C.float, rows, cols int) C.ec_Matrixf32 {
+	return C.ec_Matrixf32{
+		rows: C.size_t(rows),
+		cols: C.size_t(cols),
+		data: data,
+	}
+}
+
+func cMatrixF64(data *C.double, rows, cols int) C.ec_Matrixf64 {
+	return C.ec_Matrixf64{
+		rows: C.size_t(rows),
+		cols: C.size_t(cols),
+		data: data,
+	}
+}
+
+// AddF32 adds two float32 matrices using EigenC.
+func AddF32(a, b MatrixF32) MatrixF32 {
+	if a.Rows != b.Rows || a.Cols != b.Cols {
+		panic("dimension mismatch")
+	}
+	n := len(a.Data)
+	pa := (*C.float)(C.malloc(C.size_t(n) * C.size_t(C.sizeof_float)))
+	pb := (*C.float)(C.malloc(C.size_t(n) * C.size_t(C.sizeof_float)))
+	pc := (*C.float)(C.malloc(C.size_t(n) * C.size_t(C.sizeof_float)))
+	defer C.free(unsafe.Pointer(pa))
+	defer C.free(unsafe.Pointer(pb))
+	defer C.free(unsafe.Pointer(pc))
+
+	aSlice := (*[1 << 30]C.float)(unsafe.Pointer(pa))[:n:n]
+	bSlice := (*[1 << 30]C.float)(unsafe.Pointer(pb))[:n:n]
+	for i := 0; i < n; i++ {
+		aSlice[i] = C.float(a.Data[i])
+		bSlice[i] = C.float(b.Data[i])
+	}
+
+	ca := cMatrixF32(pa, a.Rows, a.Cols)
+	cb := cMatrixF32(pb, b.Rows, b.Cols)
+	co := cMatrixF32(pc, a.Rows, a.Cols)
+	C.ec_addf32(&ca, &cb, &co)
+
+	out := MatrixF32{Rows: a.Rows, Cols: a.Cols, Data: make([]float32, n)}
+	cSlice := (*[1 << 30]C.float)(unsafe.Pointer(pc))[:n:n]
+	for i := 0; i < n; i++ {
+		out.Data[i] = float32(cSlice[i])
+	}
+	return out
+}
+
+// AddF64 adds two float64 matrices using EigenC.
+func AddF64(a, b MatrixF64) MatrixF64 {
+	if a.Rows != b.Rows || a.Cols != b.Cols {
+		panic("dimension mismatch")
+	}
+	n := len(a.Data)
+	pa := (*C.double)(C.malloc(C.size_t(n) * C.size_t(C.sizeof_double)))
+	pb := (*C.double)(C.malloc(C.size_t(n) * C.size_t(C.sizeof_double)))
+	pc := (*C.double)(C.malloc(C.size_t(n) * C.size_t(C.sizeof_double)))
+	defer C.free(unsafe.Pointer(pa))
+	defer C.free(unsafe.Pointer(pb))
+	defer C.free(unsafe.Pointer(pc))
+
+	aSlice := (*[1 << 30]C.double)(unsafe.Pointer(pa))[:n:n]
+	bSlice := (*[1 << 30]C.double)(unsafe.Pointer(pb))[:n:n]
+	for i := 0; i < n; i++ {
+		aSlice[i] = C.double(a.Data[i])
+		bSlice[i] = C.double(b.Data[i])
+	}
+
+	ca := cMatrixF64(pa, a.Rows, a.Cols)
+	cb := cMatrixF64(pb, b.Rows, b.Cols)
+	co := cMatrixF64(pc, a.Rows, a.Cols)
+	C.ec_addf64(&ca, &cb, &co)
+
+	out := MatrixF64{Rows: a.Rows, Cols: a.Cols, Data: make([]float64, n)}
+	cSlice := (*[1 << 30]C.double)(unsafe.Pointer(pc))[:n:n]
+	for i := 0; i < n; i++ {
+		out.Data[i] = float64(cSlice[i])
+	}
+	return out
+}

--- a/go/ec/ec_test.go
+++ b/go/ec/ec_test.go
@@ -1,0 +1,27 @@
+package ec
+
+import "testing"
+
+func TestAddF32(t *testing.T) {
+	a := MatrixF32{Rows: 2, Cols: 2, Data: []float32{1, 2, 3, 4}}
+	b := MatrixF32{Rows: 2, Cols: 2, Data: []float32{5, 6, 7, 8}}
+	c := AddF32(a, b)
+	expected := []float32{6, 8, 10, 12}
+	for i, v := range expected {
+		if c.Data[i] != v {
+			t.Fatalf("c[%d] = %f, want %f", i, c.Data[i], v)
+		}
+	}
+}
+
+func TestAddF64(t *testing.T) {
+	a := MatrixF64{Rows: 2, Cols: 2, Data: []float64{1, 2, 3, 4}}
+	b := MatrixF64{Rows: 2, Cols: 2, Data: []float64{5, 6, 7, 8}}
+	c := AddF64(a, b)
+	expected := []float64{6, 8, 10, 12}
+	for i, v := range expected {
+		if c.Data[i] != v {
+			t.Fatalf("c[%d] = %f, want %f", i, c.Data[i], v)
+		}
+	}
+}

--- a/go/ec/example_test.go
+++ b/go/ec/example_test.go
@@ -1,0 +1,11 @@
+package ec
+
+import "fmt"
+
+func ExampleAddF32() {
+	a := MatrixF32{Rows: 2, Cols: 2, Data: []float32{1, 2, 3, 4}}
+	b := MatrixF32{Rows: 2, Cols: 2, Data: []float32{5, 6, 7, 8}}
+	c := AddF32(a, b)
+	fmt.Println(c.Data)
+	// Output: [6 8 10 12]
+}

--- a/go/example/main.go
+++ b/go/example/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"ec/ec"
+	"fmt"
+)
+
+func main() {
+	a := ec.MatrixF32{Rows: 2, Cols: 2, Data: []float32{1, 2, 3, 4}}
+	b := ec.MatrixF32{Rows: 2, Cols: 2, Data: []float32{5, 6, 7, 8}}
+	c := ec.AddF32(a, b)
+	fmt.Println(c.Data)
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module ec
+
+go 1.22

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -50,3 +50,11 @@ mv /tmp/c_out.txt /tmp/c_out_ppc.txt
 diff -u /tmp/c_out_host.txt /tmp/c_out_ppc.txt
 
 echo "\xE2\x9C\x93  cross-compiled EigenC checks passed (powerpc)"
+
+# Run Go tests if Go is available
+if command -v go >/dev/null; then
+  (cd "${ROOT_DIR}/go" && go test ./...)
+  echo "\xE2\x9C\x93  Go bindings tests passed"
+else
+  echo "Skipping Go tests: go not found" >&2
+fi


### PR DESCRIPTION
## Summary
- add `go/` module wrapping `ec_addf32` and `ec_addf64`
- provide Go example program and unit tests
- run Go tests from `tests/run_all.sh` when Go is available

## Testing
- `bash tests/run_all.sh` *(fails: powerpc-linux-gnu-gcc not found)*
- `go test ./...` in `go/`