### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Run setup script
+        run: sudo bash ./setup.sh
+
+      - name: Run tests
+        run: |
+          set -euo pipefail
+          ./tests/run_all.sh 2>&1 | tee run_all.log
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-logs
+          path: |
+            run_all.log
+            /tmp/c_out_host.txt
+            /tmp/c_out_ppc.txt
+            /tmp/cpp_out.txt
+            /tmp/c_out.txt
+          if-no-files: ignore


### PR DESCRIPTION
## Summary
- add basic GitHub Actions workflow that installs dependencies via `setup.sh`
- run `tests/run_all.sh` and capture logs as an artifact
- tighten CI script to stop on any error

## Testing
- `./tests/run_all.sh > /tmp/run.log 2>&1; echo exitcode:$?`
- `cat /tmp/run.log | tail -n 20`
- `sudo ./setup.sh > /tmp/setup.log 2>&1; echo exitcode:$?` (fails: Could not connect to proxy)
