### PR TITLE
Fix tests environment for powerpc toolchain

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -18,6 +18,8 @@ done
 
 apt-get update -y
 
+export CXXFLAGS="-std=c++17"
+
 for pkg in \
   build-essential gcc g++ clang lld llvm \
   clang-17 clang-tools-17 libclang-17-dev \
@@ -62,7 +64,7 @@ for pkg in \
   gcc-arm-linux-gnueabi g++-arm-linux-gnueabi \
   gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
   gcc-riscv64-linux-gnu g++-riscv64-linux-gnu \
-  gcc-powerpc-linux-gnu g++-powerpc-linux-gnu \
+  binutils-powerpc-linux-gnu gcc-powerpc-linux-gnu g++-powerpc-linux-gnu \
   gcc-powerpc64-linux-gnu g++-powerpc64-linux-gnu \
   gcc-powerpc64le-linux-gnu g++-powerpc64le-linux-gnu \
   gcc-m68k-linux-gnu g++-m68k-linux-gnu \

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -31,25 +31,7 @@ if command -v powerpc-linux-gnu-gcc >/dev/null && command -v qemu-ppc-static >/d
 else
   echo "Skipping PowerPC cross-compile test: toolchain or QEMU not found" >&2
 fi
-# Cross-compile for PowerPC and run via qemu
-if ! command -v powerpc-linux-gnu-gcc >/dev/null; then
-  echo "powerpc-linux-gnu-gcc not found" >&2
-  exit 1
-fi
-if ! command -v qemu-ppc-static >/dev/null; then
-  echo "qemu-ppc-static not found" >&2
-  exit 1
-fi
 
-powerpc-linux-gnu-gcc -static -std=c23 -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.c" -o /tmp/ec_test_ppc \
-  || powerpc-linux-gnu-gcc -static -std=c2x -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.c" -o /tmp/ec_test_ppc
-
-qemu-ppc-static /tmp/ec_test_ppc
-mv /tmp/c_out.txt /tmp/c_out_ppc.txt
-
-diff -u /tmp/c_out_host.txt /tmp/c_out_ppc.txt
-
-echo "\xE2\x9C\x93  cross-compiled EigenC checks passed (powerpc)"
 
 # Run Go tests if Go is available
 if command -v go >/dev/null; then


### PR DESCRIPTION
## Summary
- export `CXXFLAGS=-std=c++17` in setup.sh
- install `binutils-powerpc-linux-gnu` in setup
- skip powerpc cross build if toolchain/qemu missing

## Testing
- `./tests/run_all.sh`