### PR TITLE
Enable 32-bit x86 builds and document setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ int main(void) {
 The repository provides cross-compilation checks for PowerPC using
 `powerpc-linux-gnu-gcc` and `qemu-ppc-static`.  The `tests/run_all.sh` script
 handles building and executing the tests under emulation when these tools are
-present.
+present.  If 32-bit development libraries are available, the same script also
+attempts a 32-bit x86 build using `gcc -m32`.
 
 ## Go Bindings
 

--- a/setup.sh
+++ b/setup.sh
@@ -56,9 +56,16 @@ for pkg in \
   apt_pin_install "$pkg"
 done
 
+# libraries for 32-bit builds
+for pkg in \
+  gcc-multilib g++-multilib libc6-dev-i386 libstdc++6:i386; do
+  apt_pin_install "$pkg" || true
+done
+
 for pkg in \
   bcc bin86 elks-libc \
   gcc-ia64-linux-gnu g++-ia64-linux-gnu \
+  gcc-x86-64-linux-gnu g++-x86-64-linux-gnu \
   gcc-i686-linux-gnu g++-i686-linux-gnu \
   gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
   gcc-arm-linux-gnueabi g++-arm-linux-gnueabi \

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -17,6 +17,19 @@ cp /tmp/c_out.txt /tmp/c_out_host.txt
 
 echo "\xE2\x9C\x93  native EigenC vs Eigen checks passed"
 
+# 32-bit x86 build using -m32 if available
+if echo 'int main(){}' | gcc -m32 -xc -o /tmp/ccheck32 - >/dev/null 2>&1; then
+  rm /tmp/ccheck32
+  gcc -m32 -std=c23 -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.c" -o /tmp/ec_test_x86 \
+    || gcc -m32 -std=c2x -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.c" -o /tmp/ec_test_x86
+  /tmp/ec_test_x86
+  mv /tmp/c_out.txt /tmp/c_out_x86.txt
+  diff -u /tmp/c_out_host.txt /tmp/c_out_x86.txt
+  echo "\xE2\x9C\x93  cross-compiled EigenC checks passed (x86-32)"
+else
+  echo "Skipping x86 32-bit cross-compile test: toolchain not found" >&2
+fi
+
 # Cross-compile for PowerPC and run via qemu if toolchain present
 if command -v powerpc-linux-gnu-gcc >/dev/null && command -v qemu-ppc-static >/dev/null; then
   powerpc-linux-gnu-gcc -static -std=c23 -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.c" -o /tmp/ec_test_ppc \


### PR DESCRIPTION
## Summary
- add a 32-bit build step to `tests/run_all.sh`
- note 32-bit builds in README
- install multilib and x86_64 cross packages in setup script

## Testing
- `./tests/run_all.sh`