### PR TITLE
Add cross-compilation support

### DIFF
--- a/CROSS_COMPILE_NOTES.md
+++ b/CROSS_COMPILE_NOTES.md
@@ -1,0 +1,13 @@
+# Cross Compilation Notes
+
+This repository now installs an extensive set of cross-compilation toolchains via `setup.sh`.
+RISC-V (`riscv64-linux-gnu`) and LoongArch (`loongarch64-linux-gnu`) architectures are detected in
+`Eigen/src/Core/util/Macros.h`. Vectorization stubs for LASX/LSX and RISC-V RVV were also added.
+
+Missing pieces:
+
+* QEMU for LoongArch is not available in the base environment, so tests for that
+  architecture are skipped.
+* Only a minimal arithmetic kernel is tested under cross-compilation. Wider
+  coverage would require porting more of Eigen's tests.
+

--- a/Eigen/Core
+++ b/Eigen/Core
@@ -246,6 +246,18 @@
     #define EIGEN_VECTORIZE
     #define EIGEN_VECTORIZE_ZVECTOR
     #include <vecintrin.h>
+  #elif defined(__loongarch_asx)
+    #define EIGEN_VECTORIZE
+    #define EIGEN_VECTORIZE_LASX
+    #include <lasxintrin.h>
+  #elif defined(__loongarch_sx)
+    #define EIGEN_VECTORIZE
+    #define EIGEN_VECTORIZE_LSX
+    #include <lsxintrin.h>
+  #elif defined(__riscv) && defined(__riscv_vector)
+    #define EIGEN_VECTORIZE
+    #define EIGEN_VECTORIZE_RVV
+    #include <riscv_vector.h>
   #endif
 #endif
 

--- a/Eigen/src/Core/util/Macros.h
+++ b/Eigen/src/Core/util/Macros.h
@@ -210,6 +210,20 @@
   #define EIGEN_ARCH_PPC 0
 #endif
 
+/// \internal EIGEN_ARCH_RISCV set to 1 if the architecture is RISC-V
+#if defined(__riscv)
+  #define EIGEN_ARCH_RISCV 1
+#else
+  #define EIGEN_ARCH_RISCV 0
+#endif
+
+/// \internal EIGEN_ARCH_LOONGARCH set to 1 if the architecture is LoongArch
+#if defined(__loongarch64)
+  #define EIGEN_ARCH_LOONGARCH 1
+#else
+  #define EIGEN_ARCH_LOONGARCH 0
+#endif
+
 
 
 // Operating system identification, EIGEN_OS_*

--- a/setup.sh
+++ b/setup.sh
@@ -52,7 +52,7 @@ pip3 install --no-cache-dir \
 for pkg in \
   qemu-user-static \
   qemu-system-x86 qemu-system-arm qemu-system-aarch64 \
-  qemu-system-riscv64 qemu-system-ppc qemu-system-ppc64 qemu-utils; do
+  qemu-system-riscv64 qemu-system-ppc qemu-system-ppc64 qemu-system-s390x qemu-utils; do
   apt_pin_install "$pkg"
 done
 
@@ -77,6 +77,7 @@ for pkg in \
   gcc-m68k-linux-gnu g++-m68k-linux-gnu \
   gcc-hppa-linux-gnu g++-hppa-linux-gnu \
   gcc-loongarch64-linux-gnu g++-loongarch64-linux-gnu \
+  gcc-s390x-linux-gnu g++-s390x-linux-gnu \
   gcc-mips-linux-gnu g++-mips-linux-gnu \
   gcc-mipsel-linux-gnu g++-mipsel-linux-gnu \
   gcc-mips64-linux-gnuabi64 g++-mips64-linux-gnuabi64 \

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -7,10 +7,18 @@ ROOT_DIR="$(cd "$(dirname "$0")/.."; pwd)"
 gcc -std=c23 -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.c" -o /tmp/ec_test \
   || gcc -std=c2x -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.c" -o /tmp/ec_test
 
-g++ -std=c++17 -I"${ROOT_DIR}" "${ROOT_DIR}/tests/core/test_core.cpp" -o /tmp/eigen_test
+g++ -std=c++17 -I"${ROOT_DIR}" "${ROOT_DIR}/tests/core/test_core.cpp" -o /tmp/eigen_test17
+g++ -std=c++23 -I"${ROOT_DIR}" "${ROOT_DIR}/tests/core/test_core.cpp" -o /tmp/eigen_test23 || true
 
 /tmp/ec_test
-/tmp/eigen_test
+/tmp/eigen_test17
+# Save output for C++17 run
+cp /tmp/cpp_out.txt /tmp/cpp_out_cxx17.txt
+if [ -x /tmp/eigen_test23 ]; then
+  /tmp/eigen_test23
+  mv /tmp/cpp_out.txt /tmp/cpp_out_cxx23.txt
+  cp /tmp/cpp_out_cxx17.txt /tmp/cpp_out.txt
+fi
 
 python3 "${ROOT_DIR}/tests/compare_eigen_cpp_vs_c.py"
 cp /tmp/c_out.txt /tmp/c_out_host.txt
@@ -28,6 +36,21 @@ if echo 'int main(){}' | gcc -m32 -xc -o /tmp/ccheck32 - >/dev/null 2>&1; then
   echo "\xE2\x9C\x93  cross-compiled EigenC checks passed (x86-32)"
 else
   echo "Skipping x86 32-bit cross-compile test: toolchain not found" >&2
+fi
+
+# Cross-compile for RISC-V and run via qemu if toolchain present
+if command -v riscv64-linux-gnu-gcc >/dev/null && command -v qemu-riscv64-static >/dev/null; then
+  riscv64-linux-gnu-gcc -static -std=c23 -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.c" -o /tmp/ec_test_riscv \
+    || riscv64-linux-gnu-gcc -static -std=c2x -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.c" -o /tmp/ec_test_riscv
+
+  qemu-riscv64-static /tmp/ec_test_riscv
+  mv /tmp/c_out.txt /tmp/c_out_riscv.txt
+
+  diff -u /tmp/c_out_host.txt /tmp/c_out_riscv.txt
+
+  echo "\xE2\x9C\x93  cross-compiled EigenC checks passed (riscv64)"
+else
+  echo "Skipping RISC-V cross-compile test: toolchain or QEMU not found" >&2
 fi
 
 # Cross-compile for PowerPC and run via qemu if toolchain present


### PR DESCRIPTION
## Summary
- extend architecture detection macros with RISC-V and LoongArch
- add LASX/LSX and RVV vectorization stubs
- enhance setup.sh with s390x toolchain and qemu support
- run C++23 and riscv64 tests in `run_all.sh`
- document missing cross‑compile pieces

## Testing
- `./tests/run_all.sh`