### PR TITLE
Add environment tooling and pre-commit config

### DIFF
--- a/.clang-tidy-c23
+++ b/.clang-tidy-c23
@@ -1,0 +1,4 @@
+Checks: '-*,clang-diagnostic-*,bugprone-*,modernize-*'
+WarningsAsErrors: ''
+Language: C
+Standard: c23

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v17.0.6
+    hooks:
+      - id: clang-format
+        additional_dependencies: [clang-format==17.0.6]
+  - repo: https://github.com/pre-commit/mirrors-clang-tidy
+    rev: v17.0.6
+    hooks:
+      - id: clang-tidy
+        additional_dependencies: [clang-tidy==17.0.6]
+        files: "\\.(c|cc|cpp|cxx|h|hpp)$"
+      - id: clang-tidy
+        name: clang-tidy-c23
+        additional_dependencies: [clang-tidy==17.0.6]
+        args: [--config-file=.clang-tidy-c23]
+        files: "\\.(c|h)$"
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -71,4 +71,18 @@ cd go && go test ./...
 The convenience script `porter/build_all.sh` will regenerate headers and run the
 entire suite including the Go tests.
 
+## Development Environment
+
+Run `./setup.sh` to install the toolchain including GCC, Clang/LLVM, Meson and
+pre-commit.  After installation you can enable the git hooks with:
+
+```bash
+pre-commit install
+pre-commit run --all-files
+```
+
+Clang-Tidy configurations for both C23 and C++17 live in `.clang-tidy-c23` and
+`.clang-tidy`.  The project builds with either GCC or Clang; the test scripts
+use whichever compiler is available.
+
 

--- a/precommit-db/README.md
+++ b/precommit-db/README.md
@@ -1,0 +1,2 @@
+This directory stores pre-commit virtual environments built during CI.
+It is safe to delete but helps offline usage.

--- a/setup.sh
+++ b/setup.sh
@@ -132,6 +132,8 @@ unzip -d /usr/local /tmp/protoc.zip
 rm /tmp/protoc.zip
 
 command -v gmake >/dev/null 2>&1 || ln -s "$(command -v make)" /usr/local/bin/gmake
+command -v clang-tidy >/dev/null 2>&1 || ln -s "$(command -v clang-tidy-17)" /usr/local/bin/clang-tidy
+command -v clang-format >/dev/null 2>&1 || ln -s "$(command -v clang-format-17)" /usr/local/bin/clang-format
 
 apt-get clean
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- add setup symlinks for clang-format and clang-tidy
- document development environment and pre-commit usage
- provide pre-commit configuration and placeholder database
- add clang-tidy config for C23

## Testing
- `bash tests/run_all.sh`