### PR TITLE
Improve setup resilience

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,13 +2,48 @@
 set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
+# Log failures but continue
+FAIL_LOG=/tmp/setup_failures.log
+: > "$FAIL_LOG"
+
 apt_pin_install(){
   pkg="$1"
   ver=$(apt-cache show "$pkg" 2>/dev/null | awk '/^Version:/{print $2; exit}')
   if [ -n "$ver" ]; then
-    apt-get install -y "${pkg}=${ver}"
+    if ! apt-get install -y "${pkg}=${ver}"; then
+      echo "APT install failed: ${pkg}=${ver}" >> "$FAIL_LOG"
+      return 1
+    fi
   else
-    apt-get install -y "$pkg"
+    if ! apt-get install -y "$pkg"; then
+      echo "APT install failed: $pkg" >> "$FAIL_LOG"
+      return 1
+    fi
+  fi
+}
+
+# pip install wrapper that logs failures but continues
+pip_install(){
+  for pkg in "$@"; do
+    if ! pip3 install --no-cache-dir "$pkg"; then
+      echo "pip install failed: $pkg" >> "$FAIL_LOG"
+    fi
+  done
+}
+
+install_py_pkg(){
+  apt_pkg="$1"
+  case "$apt_pkg" in
+    python3-torch) pip_pkg="torch";;
+    python3-torchvision) pip_pkg="torchvision";;
+    python3-torchaudio) pip_pkg="torchaudio";;
+    python3-scikit-learn) pip_pkg="scikit-learn";;
+    python3-yaml) pip_pkg="PyYAML";;
+    *) pip_pkg="${apt_pkg#python3-}";;
+  esac
+  if ! apt_pin_install "$apt_pkg"; then
+    echo "Falling back to pip for $pip_pkg" >> "$FAIL_LOG"
+    pip_install "$pip_pkg"
   fi
 }
 
@@ -16,7 +51,7 @@ for arch in i386 armel armhf arm64 riscv64 powerpc ppc64el ia64; do
   dpkg --add-architecture "$arch"
 done
 
-apt-get update -y
+apt-get update -y || echo "apt-get update failed" >> "$FAIL_LOG"
 
 export CXXFLAGS="-std=c++23"
 
@@ -31,32 +66,35 @@ for pkg in \
   strace ltrace linux-perf systemtap systemtap-sdt-dev crash \
   valgrind kcachegrind trace-cmd kernelshark \
   libasan6 libubsan1 likwid hwloc; do
-  apt_pin_install "$pkg"
+  apt_pin_install "$pkg" || true
 done
 
 for pkg in \
-  python3 python3-pip python3-dev python3-venv python3-wheel \
+  python3 python3-pip python3-dev python3-venv python3-wheel; do
+  apt_pin_install "$pkg" || true
+done
+
+for pkg in \
   python3-numpy python3-scipy python3-pandas \
   python3-matplotlib python3-scikit-learn \
   python3-torch python3-torchvision python3-torchaudio \
   python3-onnx python3-onnxruntime python3-yaml; do
-  apt_pin_install "$pkg"
+  install_py_pkg "$pkg"
 done
 
-pip3 install clang==17.*
+pip_install clang==17.*
 
 # Ensure latest pre-commit and pytest for repository checks
-pip3 install --no-cache-dir pre-commit pytest
+pip_install pre-commit pytest
 
-pip3 install --no-cache-dir \
-  tensorflow-cpu jax jaxlib \
+pip_install tensorflow-cpu jax jaxlib \
   tensorflow-model-optimization mlflow onnxruntime-tools
 
 for pkg in \
   qemu-user-static \
   qemu-system-x86 qemu-system-arm qemu-system-aarch64 \
   qemu-system-riscv64 qemu-system-ppc qemu-system-ppc64 qemu-system-s390x qemu-utils; do
-  apt_pin_install "$pkg"
+  apt_pin_install "$pkg" || true
 done
 
 # libraries for 32-bit builds
@@ -85,7 +123,7 @@ for pkg in \
   gcc-mipsel-linux-gnu g++-mipsel-linux-gnu \
   gcc-mips64-linux-gnuabi64 g++-mips64-linux-gnuabi64 \
   gcc-mips64el-linux-gnuabi64 g++-mips64el-linux-gnuabi64; do
-  apt_pin_install "$pkg"
+  apt_pin_install "$pkg" || true
 done
 
 for pkg in \
@@ -101,7 +139,7 @@ for pkg in \
   ruby ruby-dev gem bundler php-cli php-dev composer phpunit \
   r-base r-base-dev dart flutter gnat gprbuild gfortran gnucobol \
   fpc lazarus zig nim nimble crystal shards gforth; do
-  apt_pin_install "$pkg"
+  apt_pin_install "$pkg" || true
 done
 
 for pkg in \
@@ -114,7 +152,7 @@ for pkg in \
   libwxgtk3.0-dev libwxgtk3.0-gtk3-dev \
   libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev \
   libglfw3-dev libglew-dev; do
-  apt_pin_install "$pkg"
+  apt_pin_install "$pkg" || true
 done
 
 for pkg in \
@@ -122,24 +160,33 @@ for pkg in \
   gdb lldb perf gcovr lcov bcc-tools bpftrace \
   afl afl++ honggfuzz \
   openmpi-bin libopenmpi-dev mpich; do
-  apt_pin_install "$pkg"
+  apt_pin_install "$pkg" || true
 done
 
 IA16_VER=$(curl -fsSL https://api.github.com/repos/tkchia/gcc-ia16/releases/latest | awk -F\" '/tag_name/{print $4; exit}')
-curl -fsSL "https://github.com/tkchia/gcc-ia16/releases/download/${IA16_VER}/ia16-elf-gcc-linux64.tar.xz" | tar -Jx -C /opt
-echo 'export PATH=/opt/ia16-elf-gcc/bin:$PATH' > /etc/profile.d/ia16.sh
-export PATH=/opt/ia16-elf-gcc/bin:$PATH
+if [ -n "$IA16_VER" ]; then
+  if ! curl -fsSL "https://github.com/tkchia/gcc-ia16/releases/download/${IA16_VER}/ia16-elf-gcc-linux64.tar.xz" | tar -Jx -C /opt; then
+    echo "IA16 toolchain install failed" >> "$FAIL_LOG"
+  else
+    echo 'export PATH=/opt/ia16-elf-gcc/bin:$PATH' > /etc/profile.d/ia16.sh
+    export PATH=/opt/ia16-elf-gcc/bin:$PATH
+  fi
+else
+  echo "Failed to fetch IA16 toolchain version" >> "$FAIL_LOG"
+fi
 
 PROTO_VERSION=25.1
-curl -fsSL "https://raw.githubusercontent.com/protocolbuffers/protobuf/v${PROTO_VERSION}/protoc-${PROTO_VERSION}-linux-x86_64.zip" -o /tmp/protoc.zip
-unzip -d /usr/local /tmp/protoc.zip
-rm /tmp/protoc.zip
+if curl -fsSL "https://raw.githubusercontent.com/protocolbuffers/protobuf/v${PROTO_VERSION}/protoc-${PROTO_VERSION}-linux-x86_64.zip" -o /tmp/protoc.zip; then
+  unzip -d /usr/local /tmp/protoc.zip && rm /tmp/protoc.zip || echo "protoc install failed" >> "$FAIL_LOG"
+else
+  echo "Failed to download protoc" >> "$FAIL_LOG"
+fi
 
 command -v gmake >/dev/null 2>&1 || ln -s "$(command -v make)" /usr/local/bin/gmake
 command -v clang-tidy >/dev/null 2>&1 || ln -s "$(command -v clang-tidy-17)" /usr/local/bin/clang-tidy
 command -v clang-format >/dev/null 2>&1 || ln -s "$(command -v clang-format-17)" /usr/local/bin/clang-format
 
-apt-get clean
+apt-get clean || echo "apt-get clean failed" >> "$FAIL_LOG"
 rm -rf /var/lib/apt/lists/*
 
 exit 0


### PR DESCRIPTION
## Summary
- ensure failures don't halt `setup.sh`
- log apt and pip failures to `/tmp/setup_failures.log`
- fall back to `pip` when python packages fail via apt
- handle optional downloads for IA16 and protoc gracefully

## Testing
- `bash tests/run_all.sh`
