### PR TITLE
Replace alignment macros with alignas

### DIFF
--- a/Eigen/src/Core/arch/AVX/Complex.h
+++ b/Eigen/src/Core/arch/AVX/Complex.h
@@ -311,7 +311,7 @@ template<> EIGEN_DEVICE_FUNC inline void pscatter<std::complex<double>, Packet2c
 template<> EIGEN_STRONG_INLINE std::complex<double> pfirst<Packet2cd>(const Packet2cd& a)
 {
   __m128d low = _mm256_extractf128_pd(a.v, 0);
-  EIGEN_ALIGN16 double res[2];
+  alignas(16) double res[2];
   _mm_store_pd(res, low);
   return std::complex<double>(res[0],res[1]);
 }

--- a/Eigen/src/Core/arch/AltiVec/Complex.h
+++ b/Eigen/src/Core/arch/AltiVec/Complex.h
@@ -82,14 +82,14 @@ template<> EIGEN_STRONG_INLINE void pstoreu<std::complex<float> >(std::complex<f
 
 template<> EIGEN_DEVICE_FUNC inline Packet2cf pgather<std::complex<float>, Packet2cf>(const std::complex<float>* from, Index stride)
 {
-  std::complex<float> EIGEN_ALIGN16 af[2];
+  std::complex<float> alignas(16) af[2];
   af[0] = from[0*stride];
   af[1] = from[1*stride];
   return pload<Packet2cf>(af);
 }
 template<> EIGEN_DEVICE_FUNC inline void pscatter<std::complex<float>, Packet2cf>(std::complex<float>* to, const Packet2cf& from, Index stride)
 {
-  std::complex<float> EIGEN_ALIGN16 af[2];
+  std::complex<float> alignas(16) af[2];
   pstore<std::complex<float> >((std::complex<float> *) af, from);
   to[0*stride] = af[0];
   to[1*stride] = af[1];
@@ -128,7 +128,7 @@ template<> EIGEN_STRONG_INLINE void prefetch<std::complex<float> >(const std::co
 
 template<> EIGEN_STRONG_INLINE std::complex<float>  pfirst<Packet2cf>(const Packet2cf& a)
 {
-  std::complex<float> EIGEN_ALIGN16 res[2];
+  std::complex<float> alignas(16) res[2];
   pstore((float *)&res, a.v);
 
   return res[0];
@@ -298,14 +298,14 @@ template<> EIGEN_STRONG_INLINE Packet1cd pset1<Packet1cd>(const std::complex<dou
 
 template<> EIGEN_DEVICE_FUNC inline Packet1cd pgather<std::complex<double>, Packet1cd>(const std::complex<double>* from, Index stride)
 {
-  std::complex<double> EIGEN_ALIGN16 af[2];
+  std::complex<double> alignas(16) af[2];
   af[0] = from[0*stride];
   af[1] = from[1*stride];
   return pload<Packet1cd>(af);
 }
 template<> EIGEN_DEVICE_FUNC inline void pscatter<std::complex<double>, Packet1cd>(std::complex<double>* to, const Packet1cd& from, Index stride)
 {
-  std::complex<double> EIGEN_ALIGN16 af[2];
+  std::complex<double> alignas(16) af[2];
   pstore<std::complex<double> >(af, from);
   to[0*stride] = af[0];
   to[1*stride] = af[1];
@@ -345,7 +345,7 @@ template<> EIGEN_STRONG_INLINE void prefetch<std::complex<double> >(const std::c
 
 template<> EIGEN_STRONG_INLINE std::complex<double>  pfirst<Packet1cd>(const Packet1cd& a)
 {
-  std::complex<double> EIGEN_ALIGN16 res[2];
+  std::complex<double> alignas(16) res[2];
   pstore<std::complex<double> >(res, a);
 
   return res[0];

--- a/Eigen/src/Core/arch/AltiVec/PacketMath.h
+++ b/Eigen/src/Core/arch/AltiVec/PacketMath.h
@@ -308,7 +308,7 @@ pbroadcast4<Packet4i>(const int *a,
 
 template<> EIGEN_DEVICE_FUNC inline Packet4f pgather<float, Packet4f>(const float* from, Index stride)
 {
-  float EIGEN_ALIGN16 af[4];
+  float alignas(16) af[4];
   af[0] = from[0*stride];
   af[1] = from[1*stride];
   af[2] = from[2*stride];
@@ -317,7 +317,7 @@ template<> EIGEN_DEVICE_FUNC inline Packet4f pgather<float, Packet4f>(const floa
 }
 template<> EIGEN_DEVICE_FUNC inline Packet4i pgather<int, Packet4i>(const int* from, Index stride)
 {
-  int EIGEN_ALIGN16 ai[4];
+  int alignas(16) ai[4];
   ai[0] = from[0*stride];
   ai[1] = from[1*stride];
   ai[2] = from[2*stride];
@@ -326,7 +326,7 @@ template<> EIGEN_DEVICE_FUNC inline Packet4i pgather<int, Packet4i>(const int* f
 }
 template<> EIGEN_DEVICE_FUNC inline void pscatter<float, Packet4f>(float* to, const Packet4f& from, Index stride)
 {
-  float EIGEN_ALIGN16 af[4];
+  float alignas(16) af[4];
   pstore<float>(af, from);
   to[0*stride] = af[0];
   to[1*stride] = af[1];
@@ -335,7 +335,7 @@ template<> EIGEN_DEVICE_FUNC inline void pscatter<float, Packet4f>(float* to, co
 }
 template<> EIGEN_DEVICE_FUNC inline void pscatter<int, Packet4i>(int* to, const Packet4i& from, Index stride)
 {
-  int EIGEN_ALIGN16 ai[4];
+  int alignas(16) ai[4];
   pstore<int>((int *)ai, from);
   to[0*stride] = ai[0];
   to[1*stride] = ai[1];
@@ -516,8 +516,8 @@ template<> EIGEN_STRONG_INLINE void pstoreu<float>(float*   to, const Packet4f& 
 template<> EIGEN_STRONG_INLINE void prefetch<float>(const float* addr)    { EIGEN_PPC_PREFETCH(addr); }
 template<> EIGEN_STRONG_INLINE void prefetch<int>(const int*     addr)    { EIGEN_PPC_PREFETCH(addr); }
 
-template<> EIGEN_STRONG_INLINE float  pfirst<Packet4f>(const Packet4f& a) { float EIGEN_ALIGN16 x; vec_ste(a, 0, &x); return x; }
-template<> EIGEN_STRONG_INLINE int    pfirst<Packet4i>(const Packet4i& a) { int   EIGEN_ALIGN16 x; vec_ste(a, 0, &x); return x; }
+template<> EIGEN_STRONG_INLINE float  pfirst<Packet4f>(const Packet4f& a) { float alignas(16) x; vec_ste(a, 0, &x); return x; }
+template<> EIGEN_STRONG_INLINE int    pfirst<Packet4i>(const Packet4i& a) { int   alignas(16) x; vec_ste(a, 0, &x); return x; }
 
 template<> EIGEN_STRONG_INLINE Packet4f preverse(const Packet4f& a)
 {
@@ -619,7 +619,7 @@ template<> EIGEN_STRONG_INLINE float predux_mul<Packet4f>(const Packet4f& a)
 
 template<> EIGEN_STRONG_INLINE int predux_mul<Packet4i>(const Packet4i& a)
 {
-  EIGEN_ALIGN16 int aux[4];
+  alignas(16) int aux[4];
   pstore(aux, a);
   return aux[0] * aux[1] * aux[2] * aux[3];
 }
@@ -881,14 +881,14 @@ pbroadcast4<Packet2d>(const double *a,
 
 template<> EIGEN_DEVICE_FUNC inline Packet2d pgather<double, Packet2d>(const double* from, Index stride)
 {
-  double EIGEN_ALIGN16 af[2];
+  double alignas(16) af[2];
   af[0] = from[0*stride];
   af[1] = from[1*stride];
  return pload<Packet2d>(af);
 }
 template<> EIGEN_DEVICE_FUNC inline void pscatter<double, Packet2d>(double* to, const Packet2d& from, Index stride)
 {
-  double EIGEN_ALIGN16 af[2];
+  double alignas(16) af[2];
   pstore<double>(af, from);
   to[0*stride] = af[0];
   to[1*stride] = af[1];
@@ -948,7 +948,7 @@ template<> EIGEN_STRONG_INLINE void pstoreu<double>(double*  to, const Packet2d&
 
 template<> EIGEN_STRONG_INLINE void prefetch<double>(const double* addr) { EIGEN_PPC_PREFETCH(addr); }
 
-template<> EIGEN_STRONG_INLINE double  pfirst<Packet2d>(const Packet2d& a) { double EIGEN_ALIGN16 x[2]; pstore<double>(x, a); return x[0]; }
+template<> EIGEN_STRONG_INLINE double  pfirst<Packet2d>(const Packet2d& a) { double alignas(16) x[2]; pstore<double>(x, a); return x[0]; }
 
 template<> EIGEN_STRONG_INLINE Packet2d preverse(const Packet2d& a)
 {

--- a/Eigen/src/Core/arch/CUDA/PacketMathHalf.h
+++ b/Eigen/src/Core/arch/CUDA/PacketMathHalf.h
@@ -429,7 +429,7 @@ EIGEN_STRONG_INLINE Packet16f half2float(const Packet16h& a) {
 #ifdef EIGEN_HAS_FP16_C
   return _mm512_cvtph_ps(a.x);
 #else
-  EIGEN_ALIGN64 half aux[16];
+  alignas(64) half aux[16];
   pstore(aux, a);
   float f0(aux[0]);
   float f1(aux[1]);
@@ -459,7 +459,7 @@ EIGEN_STRONG_INLINE Packet16h float2half(const Packet16f& a) {
   result.x = _mm512_cvtps_ph(a, _MM_FROUND_TO_NEAREST_INT|_MM_FROUND_NO_EXC);
   return result;
 #else
-  EIGEN_ALIGN64 float aux[16];
+  alignas(64) float aux[16];
   pstore(aux, a);
   half h0(aux[0]);
   half h1(aux[1]);
@@ -518,7 +518,7 @@ template<> EIGEN_STRONG_INLINE Packet16h pgather<Eigen::half, Packet16h>(const E
 
 template<> EIGEN_STRONG_INLINE void pscatter<half, Packet16h>(half* to, const Packet16h& from, Index stride)
 {
-  EIGEN_ALIGN64 half aux[16];
+  alignas(64) half aux[16];
   pstore(aux, from);
   to[stride*0].x = aux[0].x;
   to[stride*1].x = aux[1].x;
@@ -648,7 +648,7 @@ ptranspose(PacketBlock<Packet16h,16>& kernel) {
 
 EIGEN_STRONG_INLINE void
 ptranspose(PacketBlock<Packet16h,8>& kernel) {
-  EIGEN_ALIGN64 half in[8][16];
+  alignas(64) half in[8][16];
   pstore<half>(in[0], kernel.packet[0]);
   pstore<half>(in[1], kernel.packet[1]);
   pstore<half>(in[2], kernel.packet[2]);
@@ -658,7 +658,7 @@ ptranspose(PacketBlock<Packet16h,8>& kernel) {
   pstore<half>(in[6], kernel.packet[6]);
   pstore<half>(in[7], kernel.packet[7]);
 
-  EIGEN_ALIGN64 half out[8][16];
+  alignas(64) half out[8][16];
 
   for (int i = 0; i < 8; ++i) {
     for (int j = 0; j < 8; ++j) {
@@ -681,13 +681,13 @@ ptranspose(PacketBlock<Packet16h,8>& kernel) {
 
 EIGEN_STRONG_INLINE void
 ptranspose(PacketBlock<Packet16h,4>& kernel) {
-  EIGEN_ALIGN64 half in[4][16];
+  alignas(64) half in[4][16];
   pstore<half>(in[0], kernel.packet[0]);
   pstore<half>(in[1], kernel.packet[1]);
   pstore<half>(in[2], kernel.packet[2]);
   pstore<half>(in[3], kernel.packet[3]);
 
-  EIGEN_ALIGN64 half out[4][16];
+  alignas(64) half out[4][16];
 
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 4; ++j) {
@@ -795,7 +795,7 @@ EIGEN_STRONG_INLINE Packet8f half2float(const Packet8h& a) {
 #ifdef EIGEN_HAS_FP16_C
   return _mm256_cvtph_ps(a.x);
 #else
-  EIGEN_ALIGN32 Eigen::half aux[8];
+  alignas(32) Eigen::half aux[8];
   pstore(aux, a);
   float f0(aux[0]);
   float f1(aux[1]);
@@ -816,7 +816,7 @@ EIGEN_STRONG_INLINE Packet8h float2half(const Packet8f& a) {
   result.x = _mm256_cvtps_ph(a, _MM_FROUND_TO_NEAREST_INT|_MM_FROUND_NO_EXC);
   return result;
 #else
-  EIGEN_ALIGN32 float aux[8];
+  alignas(32) float aux[8];
   pstore(aux, a);
   Eigen::half h0(aux[0]);
   Eigen::half h1(aux[1]);
@@ -858,7 +858,7 @@ template<> EIGEN_STRONG_INLINE Packet8h pgather<Eigen::half, Packet8h>(const Eig
 
 template<> EIGEN_STRONG_INLINE void pscatter<Eigen::half, Packet8h>(Eigen::half* to, const Packet8h& from, Index stride)
 {
-  EIGEN_ALIGN32 Eigen::half aux[8];
+  alignas(32) Eigen::half aux[8];
   pstore(aux, from);
   to[stride*0].x = aux[0].x;
   to[stride*1].x = aux[1].x;
@@ -944,13 +944,13 @@ ptranspose(PacketBlock<Packet8h,8>& kernel) {
 
 EIGEN_STRONG_INLINE void
 ptranspose(PacketBlock<Packet8h,4>& kernel) {
-  EIGEN_ALIGN32 Eigen::half in[4][8];
+  alignas(32) Eigen::half in[4][8];
   pstore<Eigen::half>(in[0], kernel.packet[0]);
   pstore<Eigen::half>(in[1], kernel.packet[1]);
   pstore<Eigen::half>(in[2], kernel.packet[2]);
   pstore<Eigen::half>(in[3], kernel.packet[3]);
 
-  EIGEN_ALIGN32 Eigen::half out[4][8];
+  alignas(32) Eigen::half out[4][8];
 
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 4; ++j) {

--- a/Eigen/src/Core/arch/CUDA/TypeCasting.h
+++ b/Eigen/src/Core/arch/CUDA/TypeCasting.h
@@ -191,7 +191,7 @@ struct type_casting_traits<float, Eigen::half> {
 };
 
 template<> EIGEN_STRONG_INLINE Packet4h pcast<Packet4f, Packet4h>(const Packet4f& a) {
-  EIGEN_ALIGN16 float aux[4];
+  alignas(16) float aux[4];
   pstore(aux, a);
   Eigen::half h0(aux[0]);
   Eigen::half h1(aux[1]);

--- a/Eigen/src/Core/arch/NEON/Complex.h
+++ b/Eigen/src/Core/arch/NEON/Complex.h
@@ -146,7 +146,7 @@ template<> EIGEN_STRONG_INLINE void prefetch<std::complex<float> >(const std::co
 
 template<> EIGEN_STRONG_INLINE std::complex<float>  pfirst<Packet2cf>(const Packet2cf& a)
 {
-  std::complex<float> EIGEN_ALIGN16 x[2];
+  std::complex<float> alignas(16) x[2];
   vst1q_f32((float *)x, a.v);
   return x[0];
 }
@@ -401,7 +401,7 @@ template<> EIGEN_DEVICE_FUNC inline void pscatter<std::complex<double>, Packet1c
 
 template<> EIGEN_STRONG_INLINE std::complex<double>  pfirst<Packet1cd>(const Packet1cd& a)
 {
-  std::complex<double> EIGEN_ALIGN16 res;
+  std::complex<double> alignas(16) res;
   pstore<std::complex<double> >(&res, a);
 
   return res;

--- a/Eigen/src/Core/arch/NEON/PacketMath.h
+++ b/Eigen/src/Core/arch/NEON/PacketMath.h
@@ -308,8 +308,8 @@ template<> EIGEN_STRONG_INLINE void prefetch<float>  (const float*    addr) { EI
 template<> EIGEN_STRONG_INLINE void prefetch<int32_t>(const int32_t*  addr) { EIGEN_ARM_PREFETCH(addr); }
 
 // FIXME only store the 2 first elements ?
-template<> EIGEN_STRONG_INLINE float   pfirst<Packet4f>(const Packet4f& a) { float   EIGEN_ALIGN16 x[4]; vst1q_f32(x, a); return x[0]; }
-template<> EIGEN_STRONG_INLINE int32_t pfirst<Packet4i>(const Packet4i& a) { int32_t EIGEN_ALIGN16 x[4]; vst1q_s32(x, a); return x[0]; }
+template<> EIGEN_STRONG_INLINE float   pfirst<Packet4f>(const Packet4f& a) { float   alignas(16) x[4]; vst1q_f32(x, a); return x[0]; }
+template<> EIGEN_STRONG_INLINE int32_t pfirst<Packet4i>(const Packet4i& a) { int32_t alignas(16) x[4]; vst1q_s32(x, a); return x[0]; }
 
 template<> EIGEN_STRONG_INLINE Packet4f preverse(const Packet4f& a) {
   float32x2_t a_lo, a_hi;

--- a/Eigen/src/Core/arch/SSE/Complex.h
+++ b/Eigen/src/Core/arch/SSE/Complex.h
@@ -135,7 +135,7 @@ template<> EIGEN_STRONG_INLINE std::complex<float>  pfirst<Packet2cf>(const Pack
   #if EIGEN_GNUC_AT_MOST(4,3)
   // Workaround gcc 4.2 ICE - this is not performance wise ideal, but who cares...
   // This workaround also fix invalid code generation with gcc 4.3
-  EIGEN_ALIGN16 std::complex<float> res[2];
+  alignas(16) std::complex<float> res[2];
   _mm_store_ps((float*)res, a.v);
   return res[0];
   #else
@@ -328,7 +328,7 @@ template<> EIGEN_STRONG_INLINE void prefetch<std::complex<double> >(const std::c
 
 template<> EIGEN_STRONG_INLINE std::complex<double>  pfirst<Packet1cd>(const Packet1cd& a)
 {
-  EIGEN_ALIGN16 double res[2];
+  alignas(16) double res[2];
   _mm_store_pd(res, a.v);
   return std::complex<double>(res[0],res[1]);
 }

--- a/Eigen/src/Core/arch/SSE/PacketMath.h
+++ b/Eigen/src/Core/arch/SSE/PacketMath.h
@@ -655,7 +655,7 @@ template<> EIGEN_STRONG_INLINE int predux_mul<Packet4i>(const Packet4i& a)
   // after some experiments, it is seems this is the fastest way to implement it
   // for GCC (eg., reusing pmul is very slow !)
   // TODO try to call _mm_mul_epu32 directly
-  EIGEN_ALIGN16 int aux[4];
+  alignas(16) int aux[4];
   pstore(aux, a);
   return  (aux[0] * aux[1]) * (aux[2] * aux[3]);;
 }
@@ -678,7 +678,7 @@ template<> EIGEN_STRONG_INLINE int predux_min<Packet4i>(const Packet4i& a)
 #else
   // after some experiments, it is seems this is the fastest way to implement it
   // for GCC (eg., it does not like using std::min after the pstore !!)
-  EIGEN_ALIGN16 int aux[4];
+  alignas(16) int aux[4];
   pstore(aux, a);
   int aux0 = aux[0]<aux[1] ? aux[0] : aux[1];
   int aux2 = aux[2]<aux[3] ? aux[2] : aux[3];
@@ -704,7 +704,7 @@ template<> EIGEN_STRONG_INLINE int predux_max<Packet4i>(const Packet4i& a)
 #else
   // after some experiments, it is seems this is the fastest way to implement it
   // for GCC (eg., it does not like using std::min after the pstore !!)
-  EIGEN_ALIGN16 int aux[4];
+  alignas(16) int aux[4];
   pstore(aux, a);
   int aux0 = aux[0]>aux[1] ? aux[0] : aux[1];
   int aux2 = aux[2]>aux[3] ? aux[2] : aux[3];

--- a/Eigen/src/Core/arch/ZVector/Complex.h
+++ b/Eigen/src/Core/arch/ZVector/Complex.h
@@ -145,7 +145,7 @@ template<> EIGEN_STRONG_INLINE void prefetch<std::complex<double> >(const std::c
 
 template<> EIGEN_STRONG_INLINE std::complex<double>  pfirst<Packet1cd>(const Packet1cd& a)
 {
-  std::complex<double> EIGEN_ALIGN16 res;
+  std::complex<double> alignas(16) res;
   pstore<std::complex<double> >(&res, a);
 
   return res;
@@ -237,7 +237,7 @@ template<> EIGEN_STRONG_INLINE void pstoreu<std::complex<float> >(std::complex<f
 
 template<> EIGEN_STRONG_INLINE std::complex<float>  pfirst<Packet2cf>(const Packet2cf& a)
 {
-  std::complex<float> EIGEN_ALIGN16 res[2];
+  std::complex<float> alignas(16) res[2];
   pstore<std::complex<float> >(res, a);
 
   return res[0];
@@ -267,14 +267,14 @@ template<> EIGEN_STRONG_INLINE Packet2cf pset1<Packet2cf>(const std::complex<flo
 
 template<> EIGEN_DEVICE_FUNC inline Packet2cf pgather<std::complex<float>, Packet2cf>(const std::complex<float>* from, Index stride)
 {
-  std::complex<float> EIGEN_ALIGN16 af[2];
+  std::complex<float> alignas(16) af[2];
   af[0] = from[0*stride];
   af[1] = from[1*stride];
   return pload<Packet2cf>(af);
 }
 template<> EIGEN_DEVICE_FUNC inline void pscatter<std::complex<float>, Packet2cf>(std::complex<float>* to, const Packet2cf& from, Index stride)
 {
-  std::complex<float> EIGEN_ALIGN16 af[2];
+  std::complex<float> alignas(16) af[2];
   pstore<std::complex<float> >((std::complex<float> *) af, from);
   to[0*stride] = af[0];
   to[1*stride] = af[1];

--- a/Eigen/src/Core/arch/ZVector/PacketMath.h
+++ b/Eigen/src/Core/arch/ZVector/PacketMath.h
@@ -392,7 +392,7 @@ pbroadcast4<Packet2d>(const double *a,
 
 template<> EIGEN_DEVICE_FUNC inline Packet4i pgather<int, Packet4i>(const int* from, Index stride)
 {
-  int EIGEN_ALIGN16 ai[4];
+  alignas(16) int ai[4];
   ai[0] = from[0*stride];
   ai[1] = from[1*stride];
   ai[2] = from[2*stride];
@@ -402,7 +402,7 @@ template<> EIGEN_DEVICE_FUNC inline Packet4i pgather<int, Packet4i>(const int* f
 
 template<> EIGEN_DEVICE_FUNC inline Packet2d pgather<double, Packet2d>(const double* from, Index stride)
 {
-  double EIGEN_ALIGN16 af[2];
+  alignas(16) double af[2];
   af[0] = from[0*stride];
   af[1] = from[1*stride];
  return pload<Packet2d>(af);
@@ -410,7 +410,7 @@ template<> EIGEN_DEVICE_FUNC inline Packet2d pgather<double, Packet2d>(const dou
 
 template<> EIGEN_DEVICE_FUNC inline void pscatter<int, Packet4i>(int* to, const Packet4i& from, Index stride)
 {
-  int EIGEN_ALIGN16 ai[4];
+  int alignas(16) ai[4];
   pstore<int>((int *)ai, from);
   to[0*stride] = ai[0];
   to[1*stride] = ai[1];
@@ -420,7 +420,7 @@ template<> EIGEN_DEVICE_FUNC inline void pscatter<int, Packet4i>(int* to, const 
 
 template<> EIGEN_DEVICE_FUNC inline void pscatter<double, Packet2d>(double* to, const Packet2d& from, Index stride)
 {
-  double EIGEN_ALIGN16 af[2];
+  double alignas(16) af[2];
   pstore<double>(af, from);
   to[0*stride] = af[0];
   to[1*stride] = af[1];
@@ -494,8 +494,8 @@ template<> EIGEN_STRONG_INLINE void pstoreu<double>(double*  to, const Packet2d&
 template<> EIGEN_STRONG_INLINE void prefetch<int>(const int*       addr) { EIGEN_ZVECTOR_PREFETCH(addr); }
 template<> EIGEN_STRONG_INLINE void prefetch<double>(const double* addr) { EIGEN_ZVECTOR_PREFETCH(addr); }
 
-template<> EIGEN_STRONG_INLINE int    pfirst<Packet4i>(const Packet4i& a) { int    EIGEN_ALIGN16 x[4]; pstore(x, a); return x[0]; }
-template<> EIGEN_STRONG_INLINE double pfirst<Packet2d>(const Packet2d& a) { double EIGEN_ALIGN16 x[2]; pstore(x, a); return x[0]; }
+template<> EIGEN_STRONG_INLINE int    pfirst<Packet4i>(const Packet4i& a) { int    alignas(16) x[4]; pstore(x, a); return x[0]; }
+template<> EIGEN_STRONG_INLINE double pfirst<Packet2d>(const Packet2d& a) { double alignas(16) x[2]; pstore(x, a); return x[0]; }
 
 template<> EIGEN_STRONG_INLINE Packet4i preverse(const Packet4i& a)
 {
@@ -571,7 +571,7 @@ template<> EIGEN_STRONG_INLINE Packet2d preduxp<Packet2d>(const Packet2d* vecs)
 // mul
 template<> EIGEN_STRONG_INLINE int predux_mul<Packet4i>(const Packet4i& a)
 {
-  EIGEN_ALIGN16 int aux[4];
+  alignas(16) int aux[4];
   pstore(aux, a);
   return aux[0] * aux[1] * aux[2] * aux[3];
 }
@@ -736,7 +736,7 @@ pbroadcast4<Packet4f>(const float *a,
 
 template<> EIGEN_DEVICE_FUNC inline Packet4f pgather<float, Packet4f>(const float* from, Index stride)
 {
-  float EIGEN_ALIGN16 ai[4];
+  float alignas(16) ai[4];
   ai[0] = from[0*stride];
   ai[1] = from[1*stride];
   ai[2] = from[2*stride];
@@ -746,7 +746,7 @@ template<> EIGEN_DEVICE_FUNC inline Packet4f pgather<float, Packet4f>(const floa
 
 template<> EIGEN_DEVICE_FUNC inline void pscatter<float, Packet4f>(float* to, const Packet4f& from, Index stride)
 {
-  float EIGEN_ALIGN16 ai[4];
+  float alignas(16) ai[4];
   pstore<float>((float *)ai, from);
   to[0*stride] = ai[0];
   to[1*stride] = ai[1];
@@ -882,7 +882,7 @@ template<> EIGEN_STRONG_INLINE Packet4f ploaddup<Packet4f>(const float*    from)
   return p;
 }
 
-template<> EIGEN_STRONG_INLINE float  pfirst<Packet4f>(const Packet4f& a) { float  EIGEN_ALIGN16 x[2]; vec_st2f(a.v4f[0], &x[0]); return x[0]; }
+template<> EIGEN_STRONG_INLINE float  pfirst<Packet4f>(const Packet4f& a) { float  alignas(16) x[2]; vec_st2f(a.v4f[0], &x[0]); return x[0]; }
 
 template<> EIGEN_STRONG_INLINE Packet4f preverse(const Packet4f& a)
 {
@@ -1046,7 +1046,7 @@ pbroadcast4<Packet4f>(const float *a,
 
 template<> EIGEN_DEVICE_FUNC inline Packet4f pgather<float, Packet4f>(const float* from, Index stride)
 {
-  float EIGEN_ALIGN16 af[4];
+  float alignas(16) af[4];
   af[0] = from[0*stride];
   af[1] = from[1*stride];
   af[2] = from[2*stride];
@@ -1056,7 +1056,7 @@ template<> EIGEN_DEVICE_FUNC inline Packet4f pgather<float, Packet4f>(const floa
 
 template<> EIGEN_DEVICE_FUNC inline void pscatter<float, Packet4f>(float* to, const Packet4f& from, Index stride)
 {
-  float EIGEN_ALIGN16 af[4];
+  float alignas(16) af[4];
   pstore<float>((float*)af, from);
   to[0*stride] = af[0];
   to[1*stride] = af[1];
@@ -1081,7 +1081,7 @@ template<> EIGEN_STRONG_INLINE Packet4f pround<Packet4f> (const Packet4f& a) { r
 template<> EIGEN_STRONG_INLINE Packet4f pceil<Packet4f>  (const Packet4f& a) { return vec_ceil(a); }
 template<> EIGEN_STRONG_INLINE Packet4f pfloor<Packet4f> (const Packet4f& a) { return vec_floor(a); }
 template<> EIGEN_STRONG_INLINE Packet4f pabs<Packet4f>   (const Packet4f& a) { return vec_abs(a); }
-template<> EIGEN_STRONG_INLINE float pfirst<Packet4f>(const Packet4f& a) { float EIGEN_ALIGN16 x[4]; pstore(x, a); return x[0]; }
+template<> EIGEN_STRONG_INLINE float pfirst<Packet4f>(const Packet4f& a) { float alignas(16) x[4]; pstore(x, a); return x[0]; }
 
 template<> EIGEN_STRONG_INLINE Packet4f ploaddup<Packet4f>(const float* from)
 {

--- a/Eigen/src/Core/products/GeneralMatrixMatrix.h
+++ b/Eigen/src/Core/products/GeneralMatrixMatrix.h
@@ -291,11 +291,11 @@ class gemm_blocking_space<StorageOrder,_LhsScalar,_RhsScalar,MaxRows, MaxCols, M
     };
 
 #if EIGEN_MAX_STATIC_ALIGN_BYTES >= EIGEN_DEFAULT_ALIGN_BYTES
-    EIGEN_ALIGN_MAX LhsScalar m_staticA[SizeA];
-    EIGEN_ALIGN_MAX RhsScalar m_staticB[SizeB];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) LhsScalar m_staticA[SizeA];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) RhsScalar m_staticB[SizeB];
 #else
-    EIGEN_ALIGN_MAX char m_staticA[SizeA * sizeof(LhsScalar) + EIGEN_DEFAULT_ALIGN_BYTES-1];
-    EIGEN_ALIGN_MAX char m_staticB[SizeB * sizeof(RhsScalar) + EIGEN_DEFAULT_ALIGN_BYTES-1];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) char m_staticA[SizeA * sizeof(LhsScalar) + EIGEN_DEFAULT_ALIGN_BYTES-1];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) char m_staticB[SizeB * sizeof(RhsScalar) + EIGEN_DEFAULT_ALIGN_BYTES-1];
 #endif
 
   public:

--- a/Eigen/src/Core/util/Macros.h
+++ b/Eigen/src/Core/util/Macros.h
@@ -695,17 +695,23 @@ namespace Eigen {
  * If we made alignment depend on whether or not EIGEN_VECTORIZE is defined, it would be impossible to link
  * vectorized and non-vectorized code.
  */
-#if (defined EIGEN_CUDACC)
-  #define EIGEN_ALIGN_TO_BOUNDARY(n) __align__(n)
-#elif EIGEN_COMP_GNUC || EIGEN_COMP_PGI || EIGEN_COMP_IBM || EIGEN_COMP_ARM
-  #define EIGEN_ALIGN_TO_BOUNDARY(n) __attribute__((aligned(n)))
-#elif EIGEN_COMP_MSVC
-  #define EIGEN_ALIGN_TO_BOUNDARY(n) __declspec(align(n))
-#elif EIGEN_COMP_SUNCC
-  // FIXME not sure about this one:
-  #define EIGEN_ALIGN_TO_BOUNDARY(n) __attribute__((aligned(n)))
+#if defined(__cplusplus) && __cplusplus >= 201103L
+  // Prefer the standard alignas specifier when available.
+  // These macros are deprecated and will expand to alignas.
+  #define EIGEN_ALIGN_TO_BOUNDARY(n) alignas(n)
 #else
-  #error Please tell me what is the equivalent of __attribute__((aligned(n))) for your compiler
+  #if (defined EIGEN_CUDACC)
+    #define EIGEN_ALIGN_TO_BOUNDARY(n) __align__(n)
+  #elif EIGEN_COMP_GNUC || EIGEN_COMP_PGI || EIGEN_COMP_IBM || EIGEN_COMP_ARM
+    #define EIGEN_ALIGN_TO_BOUNDARY(n) __attribute__((aligned(n)))
+  #elif EIGEN_COMP_MSVC
+    #define EIGEN_ALIGN_TO_BOUNDARY(n) __declspec(align(n))
+  #elif EIGEN_COMP_SUNCC
+    // FIXME not sure about this one:
+    #define EIGEN_ALIGN_TO_BOUNDARY(n) __attribute__((aligned(n)))
+  #else
+    #error Please tell me what is the equivalent of __attribute__((aligned(n))) for your compiler
+  #endif
 #endif
 
 // If the user explicitly disable vectorization, then we also disable alignment
@@ -797,7 +803,8 @@ namespace Eigen {
 // Henceforth, only EIGEN_MAX_STATIC_ALIGN_BYTES should be used.
 
 
-// Shortcuts to EIGEN_ALIGN_TO_BOUNDARY
+// Shortcuts to EIGEN_ALIGN_TO_BOUNDARY.
+// Deprecated: prefer using the alignas specifier directly.
 #define EIGEN_ALIGN8  EIGEN_ALIGN_TO_BOUNDARY(8)
 #define EIGEN_ALIGN16 EIGEN_ALIGN_TO_BOUNDARY(16)
 #define EIGEN_ALIGN32 EIGEN_ALIGN_TO_BOUNDARY(32)

--- a/Eigen/src/LU/arch/Inverse_SSE.h
+++ b/Eigen/src/LU/arch/Inverse_SSE.h
@@ -44,7 +44,7 @@ struct compute_inverse_size4<Architecture::SSE, float, MatrixType, ResultType>
   static void run(const MatrixType& mat, ResultType& result)
   {
     ActualMatrixType matrix(mat);
-    EIGEN_ALIGN16 const unsigned int _Sign_PNNP[4] = { 0x00000000, 0x80000000, 0x80000000, 0x00000000 };
+    alignas(16) const unsigned int _Sign_PNNP[4] = { 0x00000000, 0x80000000, 0x80000000, 0x00000000 };
 
     // Load the full matrix into registers
     __m128 _L1 = matrix.template packet<MatrixAlignment>( 0);

--- a/doc/A05_PortingFrom2To3.dox
+++ b/doc/A05_PortingFrom2To3.dox
@@ -259,7 +259,9 @@ use it unless you are sure of what you are doing, i.e., you have rigourosly meas
 
 \section AlignMacros Alignment-related macros
 
-The EIGEN_ALIGN_128 macro has been renamed to EIGEN_ALIGN16. Don't be surprised, it's just that we switched to counting in bytes ;-)
+The `EIGEN_ALIGN_128` macro was renamed to `EIGEN_ALIGN16` and is now deprecated
+in favor of the C++11 `alignas` specifier. Existing macros expand to `alignas` so
+older code continues to compile.
 
 The \link TopicPreprocessorDirectivesPerformance EIGEN_DONT_ALIGN \endlink option still exists in Eigen 3, but it has a new cousin: \link TopicPreprocessorDirectivesPerformance  EIGEN_DONT_ALIGN_STATICALLY.\endlink It allows to get rid of all static alignment issues while keeping alignment of dynamic-size heap-allocated arrays. Vectorization of statically allocated arrays is still preserved (unless you define \link TopicPreprocessorDirectivesPerformance EIGEN_UNALIGNED_VECTORIZE \endlink =0), at the cost of unaligned memory stores.
 

--- a/test/first_aligned.cpp
+++ b/test/first_aligned.cpp
@@ -28,7 +28,7 @@ struct some_non_vectorizable_type { float x; };
 
 void test_first_aligned()
 {
-  EIGEN_ALIGN16 float array_float[100];
+  alignas(16) float array_float[100];
   test_first_aligned_helper(array_float, 50);
   test_first_aligned_helper(array_float+1, 50);
   test_first_aligned_helper(array_float+2, 50);
@@ -36,7 +36,7 @@ void test_first_aligned()
   test_first_aligned_helper(array_float+4, 50);
   test_first_aligned_helper(array_float+5, 50);
   
-  EIGEN_ALIGN16 double array_double[100];
+  alignas(16) double array_double[100];
   test_first_aligned_helper(array_double, 50);
   test_first_aligned_helper(array_double+1, 50);
   test_first_aligned_helper(array_double+2, 50);

--- a/test/geo_hyperplane.cpp
+++ b/test/geo_hyperplane.cpp
@@ -158,9 +158,9 @@ template<typename Scalar> void hyperplane_alignment()
   typedef Hyperplane<Scalar,3,AutoAlign> Plane3a;
   typedef Hyperplane<Scalar,3,DontAlign> Plane3u;
 
-  EIGEN_ALIGN_MAX Scalar array1[4];
-  EIGEN_ALIGN_MAX Scalar array2[4];
-  EIGEN_ALIGN_MAX Scalar array3[4+1];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar array1[4];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar array2[4];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar array3[4+1];
   Scalar* array3u = array3+1;
 
   Plane3a *p1 = ::new(reinterpret_cast<void*>(array1)) Plane3a;

--- a/test/geo_parametrizedline.cpp
+++ b/test/geo_parametrizedline.cpp
@@ -93,9 +93,9 @@ template<typename Scalar> void parametrizedline_alignment()
   typedef ParametrizedLine<Scalar,4,AutoAlign> Line4a;
   typedef ParametrizedLine<Scalar,4,DontAlign> Line4u;
 
-  EIGEN_ALIGN_MAX Scalar array1[16];
-  EIGEN_ALIGN_MAX Scalar array2[16];
-  EIGEN_ALIGN_MAX Scalar array3[16+1];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar array1[16];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar array2[16];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar array3[16+1];
   Scalar* array3u = array3+1;
 
   Line4a *p1 = ::new(reinterpret_cast<void*>(array1)) Line4a;

--- a/test/geo_quaternion.cpp
+++ b/test/geo_quaternion.cpp
@@ -186,9 +186,9 @@ template<typename Scalar> void mapQuaternion(void){
           v1 = Vector3::Random();
   Scalar  a = internal::random<Scalar>(-Scalar(EIGEN_PI), Scalar(EIGEN_PI));
 
-  EIGEN_ALIGN_MAX Scalar array1[4];
-  EIGEN_ALIGN_MAX Scalar array2[4];
-  EIGEN_ALIGN_MAX Scalar array3[4+1];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar array1[4];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar array2[4];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar array3[4+1];
   Scalar* array3unaligned = array3+1;
   
   MQuaternionA    mq1(array1);
@@ -250,9 +250,9 @@ template<typename Scalar> void quaternionAlignment(void){
   typedef Quaternion<Scalar,AutoAlign> QuaternionA;
   typedef Quaternion<Scalar,DontAlign> QuaternionUA;
 
-  EIGEN_ALIGN_MAX Scalar array1[4];
-  EIGEN_ALIGN_MAX Scalar array2[4];
-  EIGEN_ALIGN_MAX Scalar array3[4+1];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar array1[4];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar array2[4];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar array3[4+1];
   Scalar* arrayunaligned = array3+1;
 
   QuaternionA *q1 = ::new(reinterpret_cast<void*>(array1)) QuaternionA;

--- a/test/geo_transformations.cpp
+++ b/test/geo_transformations.cpp
@@ -565,9 +565,9 @@ template<typename Scalar> void transform_alignment()
   typedef Transform<Scalar,3,Projective,AutoAlign> Projective3a;
   typedef Transform<Scalar,3,Projective,DontAlign> Projective3u;
 
-  EIGEN_ALIGN_MAX Scalar array1[16];
-  EIGEN_ALIGN_MAX Scalar array2[16];
-  EIGEN_ALIGN_MAX Scalar array3[16+1];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar array1[16];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar array2[16];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar array3[16+1];
   Scalar* array3u = array3+1;
 
   Projective3a *p1 = ::new(reinterpret_cast<void*>(array1)) Projective3a;

--- a/test/packetmath.cpp
+++ b/test/packetmath.cpp
@@ -119,10 +119,10 @@ template<typename Scalar> void packetmath()
 
   const int max_size = PacketSize > 4 ? PacketSize : 4;
   const int size = PacketSize*max_size;
-  EIGEN_ALIGN_MAX Scalar data1[size];
-  EIGEN_ALIGN_MAX Scalar data2[size];
-  EIGEN_ALIGN_MAX Packet packets[PacketSize*2];
-  EIGEN_ALIGN_MAX Scalar ref[size];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar data1[size];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar data2[size];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Packet packets[PacketSize*2];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar ref[size];
   RealScalar refvalue = 0;
   for (int i=0; i<size; ++i)
   {
@@ -291,13 +291,13 @@ template<typename Scalar> void packetmath()
   if (PacketTraits::HasBlend) {
     Packet thenPacket = internal::pload<Packet>(data1);
     Packet elsePacket = internal::pload<Packet>(data2);
-    EIGEN_ALIGN_MAX internal::Selector<PacketSize> selector;
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) internal::Selector<PacketSize> selector;
     for (int i = 0; i < PacketSize; ++i) {
       selector.select[i] = i;
     }
 
     Packet blend = internal::pblend(selector, thenPacket, elsePacket);
-    EIGEN_ALIGN_MAX Scalar result[size];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar result[size];
     internal::pstore(result, blend);
     for (int i = 0; i < PacketSize; ++i) {
       VERIFY(isApproxAbs(result[i], (selector.select[i] ? data1[i] : data2[i]), refvalue));
@@ -333,9 +333,9 @@ template<typename Scalar> void packetmath_real()
   const int PacketSize = PacketTraits::size;
 
   const int size = PacketSize*4;
-  EIGEN_ALIGN_MAX Scalar data1[PacketTraits::size*4];
-  EIGEN_ALIGN_MAX Scalar data2[PacketTraits::size*4];
-  EIGEN_ALIGN_MAX Scalar ref[PacketTraits::size*4];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar data1[PacketTraits::size*4];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar data2[PacketTraits::size*4];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar ref[PacketTraits::size*4];
 
   for (int i=0; i<size; ++i)
   {
@@ -488,9 +488,9 @@ template<typename Scalar> void packetmath_notcomplex()
   typedef typename PacketTraits::type Packet;
   const int PacketSize = PacketTraits::size;
 
-  EIGEN_ALIGN_MAX Scalar data1[PacketTraits::size*4];
-  EIGEN_ALIGN_MAX Scalar data2[PacketTraits::size*4];
-  EIGEN_ALIGN_MAX Scalar ref[PacketTraits::size*4];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar data1[PacketTraits::size*4];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar data2[PacketTraits::size*4];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar ref[PacketTraits::size*4];
 
   Array<Scalar,Dynamic,1>::Map(data1, PacketTraits::size*4).setRandom();
 
@@ -553,10 +553,10 @@ template<typename Scalar> void packetmath_complex()
   const int PacketSize = PacketTraits::size;
 
   const int size = PacketSize*4;
-  EIGEN_ALIGN_MAX Scalar data1[PacketSize*4];
-  EIGEN_ALIGN_MAX Scalar data2[PacketSize*4];
-  EIGEN_ALIGN_MAX Scalar ref[PacketSize*4];
-  EIGEN_ALIGN_MAX Scalar pval[PacketSize*4];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar data1[PacketSize*4];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar data2[PacketSize*4];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar ref[PacketSize*4];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar pval[PacketSize*4];
 
   for (int i=0; i<size; ++i)
   {
@@ -583,7 +583,7 @@ template<typename Scalar> void packetmath_scatter_gather()
   typedef typename PacketTraits::type Packet;
   typedef typename NumTraits<Scalar>::Real RealScalar;
   const int PacketSize = PacketTraits::size;
-  EIGEN_ALIGN_MAX Scalar data1[PacketSize];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar data1[PacketSize];
   RealScalar refvalue = 0;
   for (int i=0; i<PacketSize; ++i) {
     data1[i] = internal::random<Scalar>()/RealScalar(PacketSize);
@@ -591,7 +591,7 @@ template<typename Scalar> void packetmath_scatter_gather()
 
   int stride = internal::random<int>(1,20);
 
-  EIGEN_ALIGN_MAX Scalar buffer[PacketSize*20];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar buffer[PacketSize*20];
   memset(buffer, 0, 20*PacketSize*sizeof(Scalar));
   Packet packet = internal::pload<Packet>(data1);
   internal::pscatter<Scalar, Packet>(buffer, packet, stride);

--- a/test/unalignedassert.cpp
+++ b/test/unalignedassert.cpp
@@ -62,7 +62,7 @@ struct TestNew4
 struct TestNew5
 {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  float f; // try the f at first -- the EIGEN_ALIGN_MAX attribute of m should make that still work
+  float f; // try the f at first -- the alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) attribute of m should make that still work
   Matrix4f m;
 };
 

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorBroadcasting.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorBroadcasting.h
@@ -287,7 +287,7 @@ struct TensorEvaluator<const TensorBroadcastingOp<Broadcast, ArgType>, Device>
     if (innermostLoc + PacketSize <= m_impl.dimensions()[0]) {
       return m_impl.template packet<Unaligned>(inputIndex);
     } else {
-      EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
+      alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
       values[0] = m_impl.coeff(inputIndex);
       for (int i = 1; i < PacketSize; ++i) {
         values[i] = coeffColMajor(originalIndex+i);
@@ -339,7 +339,7 @@ struct TensorEvaluator<const TensorBroadcastingOp<Broadcast, ArgType>, Device>
     if (innermostLoc + PacketSize <= m_impl.dimensions()[NumDims-1]) {
       return m_impl.template packet<Unaligned>(inputIndex);
     } else {
-      EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
+      alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
       values[0] = m_impl.coeff(inputIndex);
       for (int i = 1; i < PacketSize; ++i) {
         values[i] = coeffRowMajor(originalIndex+i);

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorChipping.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorChipping.h
@@ -212,7 +212,7 @@ struct TensorEvaluator<const TensorChippingOp<DimId, ArgType>, Device>
       // m_stride is equal to 1, so let's avoid the integer division.
       eigen_assert(m_stride == 1);
       Index inputIndex = index * m_inputStride + m_inputOffset;
-      EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
+      alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
       for (int i = 0; i < PacketSize; ++i) {
         values[i] = m_impl.coeff(inputIndex);
         inputIndex += m_inputStride;
@@ -232,7 +232,7 @@ struct TensorEvaluator<const TensorChippingOp<DimId, ArgType>, Device>
         return m_impl.template packet<LoadMode>(inputIndex);
       } else {
         // Cross the stride boundary. Fallback to slow path.
-        EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
+        alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
         for (int i = 0; i < PacketSize; ++i) {
           values[i] = coeff(index);
           ++index;
@@ -364,7 +364,7 @@ struct TensorEvaluator<TensorChippingOp<DimId, ArgType>, Device>
   (static_cast<int>(this->Layout) == static_cast<int>(RowMajor) && this->m_dim.actualDim() == NumInputDims-1)) {
       // m_stride is equal to 1, so let's avoid the integer division.
       eigen_assert(this->m_stride == 1);
-      EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
+      alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
       internal::pstore<CoeffReturnType, PacketReturnType>(values, x);
       Index inputIndex = index * this->m_inputStride + this->m_inputOffset;
       for (int i = 0; i < PacketSize; ++i) {
@@ -384,7 +384,7 @@ struct TensorEvaluator<TensorChippingOp<DimId, ArgType>, Device>
         this->m_impl.template writePacket<StoreMode>(inputIndex, x);
       } else {
         // Cross stride boundary. Fallback to slow path.
-        EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
+        alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
         internal::pstore<CoeffReturnType, PacketReturnType>(values, x);
         for (int i = 0; i < PacketSize; ++i) {
           this->coeffRef(index) = values[i];

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorConcatenation.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorConcatenation.h
@@ -254,7 +254,7 @@ struct TensorEvaluator<const TensorConcatenationOp<Axis, LeftArgType, RightArgTy
     EIGEN_STATIC_ASSERT((packetSize > 1), YOU_MADE_A_PROGRAMMING_MISTAKE)
     eigen_assert(index + packetSize - 1 < dimensions().TotalSize());
 
-    EIGEN_ALIGN_MAX CoeffReturnType values[packetSize];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) CoeffReturnType values[packetSize];
     for (int i = 0; i < packetSize; ++i) {
       values[i] = coeff(index+i);
     }
@@ -356,7 +356,7 @@ template<typename Axis, typename LeftArgType, typename RightArgType, typename De
     EIGEN_STATIC_ASSERT((packetSize > 1), YOU_MADE_A_PROGRAMMING_MISTAKE)
     eigen_assert(index + packetSize - 1 < this->dimensions().TotalSize());
 
-    EIGEN_ALIGN_MAX CoeffReturnType values[packetSize];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) CoeffReturnType values[packetSize];
     internal::pstore<CoeffReturnType, PacketReturnType>(values, x);
     for (int i = 0; i < packetSize; ++i) {
       coeffRef(index+i) = values[i];

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorContractionMapper.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorContractionMapper.h
@@ -271,7 +271,7 @@ class BaseTensorContractionMapper : public SimpleTensorContractionMapper<Scalar,
       return this->m_tensor.template packet<AlignmentType>(first);
     }
 
-    EIGEN_ALIGN_MAX Scalar data[packet_size];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar data[packet_size];
 
     data[0] = this->m_tensor.coeff(first);
     for (Index k = 1; k < packet_size - 1; k += 2) {
@@ -300,7 +300,7 @@ class BaseTensorContractionMapper : public SimpleTensorContractionMapper<Scalar,
     if (half_packet_size == packet_size) {
       return loadPacket<AlignmentType>(i, j);
     }
-    EIGEN_ALIGN_MAX Scalar data[half_packet_size];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar data[half_packet_size];
     for (Index k = 0; k < half_packet_size; k++) {
       data[k] = operator()(i + k, j);
     }
@@ -330,13 +330,13 @@ class BaseTensorContractionMapper<Scalar, Index, side, Tensor, nocontract_t, con
   typedef typename Tensor::PacketReturnType Packet;
   template <int> EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE Packet loadPacket(Index i, Index j) const {
-    EIGEN_ALIGN_MAX Scalar data[1];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar data[1];
     data[0] = this->m_tensor.coeff(this->computeIndex(i, j));
     return pload<typename Tensor::PacketReturnType>(data);
   }
   template <typename PacketT,int> EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE PacketT load(Index i, Index j) const {
-    EIGEN_ALIGN_MAX Scalar data[1];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar data[1];
     data[0] = this->m_tensor.coeff(this->computeIndex(i, j));
     return pload<PacketT>(data);
   }

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorConversion.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorConversion.h
@@ -128,7 +128,7 @@ struct PacketConverter<TensorEvaluator, SrcPacket, TgtPacket, 1, 2> {
       typedef typename internal::unpacket_traits<SrcPacket>::type SrcType;
       typedef typename internal::unpacket_traits<TgtPacket>::type TgtType;
       internal::scalar_cast_op<SrcType, TgtType> converter;
-      EIGEN_ALIGN_MAX typename internal::unpacket_traits<TgtPacket>::type values[TgtPacketSize];
+      alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::unpacket_traits<TgtPacket>::type values[TgtPacketSize];
       for (int i = 0; i < TgtPacketSize; ++i) {
         values[i] = converter(m_impl.coeff(index+i));
       }
@@ -255,7 +255,7 @@ struct TensorEvaluator<const TensorConversionOp<TargetType, ArgType>, Device>
   struct PacketConv {
     static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE PacketReturnType run(const TensorEvaluator<ArgType, Device>& impl, Index index) {
       internal::scalar_cast_op<SrcType, TargetType> converter;
-      EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
+      alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
       for (int i = 0; i < PacketSize; ++i) {
         values[i] = converter(impl.coeff(index+i));
       }

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorConvolution.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorConvolution.h
@@ -437,7 +437,7 @@ struct TensorEvaluator<const TensorConvolutionOp<Indices, InputArgType, KernelAr
       convolvePacket(startInputs[0], 0, NumKernelDims-1, result);
       return result;
     } else {
-      EIGEN_ALIGN_MAX Scalar data[PacketSize];
+      alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar data[PacketSize];
       data[0] = Scalar(0);
       convolve(startInputs[0], 0, NumKernelDims-1, data[0]);
       for (int i = 1; i < PacketSize-1; ++i) {

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorGenerator.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorGenerator.h
@@ -141,7 +141,7 @@ struct TensorEvaluator<const TensorGeneratorOp<Generator, ArgType>, Device>
     EIGEN_STATIC_ASSERT((packetSize > 1), YOU_MADE_A_PROGRAMMING_MISTAKE)
     eigen_assert(index+packetSize-1 < dimensions().TotalSize());
 
-    EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type values[packetSize];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type values[packetSize];
     for (int i = 0; i < packetSize; ++i) {
       values[i] = coeff(index+i);
     }

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorImagePatch.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorImagePatch.h
@@ -486,7 +486,7 @@ struct TensorEvaluator<const TensorImagePatchOp<Rows, Cols, ArgType>, Device>
  protected:
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE PacketReturnType packetWithPossibleZero(Index index) const
   {
-    EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
     for (int i = 0; i < PacketSize; ++i) {
       values[i] = coeff(index+i);
     }

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorInflation.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorInflation.h
@@ -193,7 +193,7 @@ struct TensorEvaluator<const TensorInflationOp<Strides, ArgType>, Device>
     EIGEN_STATIC_ASSERT((PacketSize > 1), YOU_MADE_A_PROGRAMMING_MISTAKE)
     eigen_assert(index+PacketSize-1 < dimensions().TotalSize());
 
-    EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
     for (int i = 0; i < PacketSize; ++i) {
       values[i] = coeff(index+i);
     }

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorMorphing.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorMorphing.h
@@ -454,7 +454,7 @@ struct TensorEvaluator<const TensorSlicingOp<StartIndices, Sizes, ArgType>, Devi
       return rslt;
     }
     else {
-      EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type values[packetSize];
+      alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type values[packetSize];
       values[0] = m_impl.coeff(inputIndices[0]);
       values[packetSize-1] = m_impl.coeff(inputIndices[1]);
       for (int i = 1; i < packetSize-1; ++i) {
@@ -610,7 +610,7 @@ struct TensorEvaluator<TensorSlicingOp<StartIndices, Sizes, ArgType>, Device>
       this->m_impl.template writePacket<StoreMode>(inputIndices[0], x);
     }
     else {
-      EIGEN_ALIGN_MAX CoeffReturnType values[packetSize];
+      alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) CoeffReturnType values[packetSize];
       internal::pstore<CoeffReturnType, PacketReturnType>(values, x);
       this->m_impl.coeffRef(inputIndices[0]) = values[0];
       this->m_impl.coeffRef(inputIndices[1]) = values[packetSize-1];

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorPadding.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorPadding.h
@@ -380,7 +380,7 @@ struct TensorEvaluator<const TensorPaddingOp<PaddingDimensions, ArgType>, Device
 
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE PacketReturnType packetWithPossibleZero(Index index) const
   {
-    EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
     for (int i = 0; i < PacketSize; ++i) {
       values[i] = coeff(index+i);
     }

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorPatch.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorPatch.h
@@ -238,7 +238,7 @@ struct TensorEvaluator<const TensorPatchOp<PatchDim, ArgType>, Device>
       return rslt;
     }
     else {
-      EIGEN_ALIGN_MAX CoeffReturnType values[PacketSize];
+      alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) CoeffReturnType values[PacketSize];
       values[0] = m_impl.coeff(inputIndices[0]);
       values[PacketSize-1] = m_impl.coeff(inputIndices[1]);
       for (int i = 1; i < PacketSize-1; ++i) {

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorRandom.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorRandom.h
@@ -162,7 +162,7 @@ template <typename T> class UniformRandomGenerator {
   template<typename Packet, typename Index> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   Packet packetOp(Index i) const {
     const int packetSize = internal::unpacket_traits<Packet>::size;
-    EIGEN_ALIGN_MAX T values[packetSize];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) T values[packetSize];
     for (int j = 0; j < packetSize; ++j) {
       values[j] = RandomToTypeUniform<T>(&m_state, i);
     }
@@ -237,7 +237,7 @@ template <typename T> class NormalRandomGenerator {
   template<typename Packet, typename Index> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   Packet packetOp(Index i) const {
     const int packetSize = internal::unpacket_traits<Packet>::size;
-    EIGEN_ALIGN_MAX T values[packetSize];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) T values[packetSize];
     for (int j = 0; j < packetSize; ++j) {
       values[j] = RandomToTypeNormal<T>(&m_state, i);
     }

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorReduction.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorReduction.h
@@ -633,7 +633,7 @@ struct TensorEvaluator<const TensorReductionOp<Op, Dims, ArgType, MakePointer_>,
       return internal::pload<PacketReturnType>(m_result + index);
     }
 
-    EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
     if (ReducingInnerMostDims) {
       const Index num_values_to_reduce =
         (static_cast<int>(Layout) == static_cast<int>(ColMajor)) ? m_preservedStrides[0] : m_preservedStrides[NumPreservedStrides - 1];

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorReverse.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorReverse.h
@@ -201,7 +201,7 @@ struct TensorEvaluator<const TensorReverseOp<ReverseDimensions, ArgType>, Device
 
     // TODO(ndjaitly): write a better packing routine that uses
     // local structure.
-    EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type
                                                             values[PacketSize];
     for (int i = 0; i < PacketSize; ++i) {
       values[i] = coeff(index+i);
@@ -279,7 +279,7 @@ struct TensorEvaluator<TensorReverseOp<ReverseDimensions, ArgType>, Device>
     eigen_assert(index+PacketSize-1 < dimensions().TotalSize());
 
     // This code is pilfered from TensorMorphing.h
-    EIGEN_ALIGN_MAX CoeffReturnType values[PacketSize];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) CoeffReturnType values[PacketSize];
     internal::pstore<CoeffReturnType, PacketReturnType>(values, x);
     for (int i = 0; i < PacketSize; ++i) {
       this->coeffRef(index+i) = values[i];

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorShuffling.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorShuffling.h
@@ -170,7 +170,7 @@ struct TensorEvaluator<const TensorShufflingOp<Shuffle, ArgType>, Device>
     EIGEN_STATIC_ASSERT((PacketSize > 1), YOU_MADE_A_PROGRAMMING_MISTAKE)
     eigen_assert(index+PacketSize-1 < dimensions().TotalSize());
 
-    EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
     for (int i = 0; i < PacketSize; ++i) {
       values[i] = coeff(index+i);
     }
@@ -257,7 +257,7 @@ struct TensorEvaluator<TensorShufflingOp<Shuffle, ArgType>, Device>
   {
     EIGEN_STATIC_ASSERT((PacketSize > 1), YOU_MADE_A_PROGRAMMING_MISTAKE)
 
-    EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
     internal::pstore<CoeffReturnType, PacketReturnType>(values, x);
     for (int i = 0; i < PacketSize; ++i) {
       this->coeffRef(index+i) = values[i];

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorStorage.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorStorage.h
@@ -43,7 +43,7 @@ class TensorStorage
 
   // Allocate an array of size at least one to prevent compiler warnings.
   static const std::size_t MinSize = max_n_1<Size>::size;
-  EIGEN_ALIGN_MAX T m_data[MinSize];
+  alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) T m_data[MinSize];
 
   FixedDimensions m_dimensions;
 

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorStriding.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorStriding.h
@@ -198,7 +198,7 @@ struct TensorEvaluator<const TensorStridingOp<Strides, ArgType>, Device>
       return rslt;
     }
     else {
-      EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
+      alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
       values[0] = m_impl.coeff(inputIndices[0]);
       values[PacketSize-1] = m_impl.coeff(inputIndices[1]);
       for (int i = 1; i < PacketSize-1; ++i) {
@@ -332,7 +332,7 @@ struct TensorEvaluator<TensorStridingOp<Strides, ArgType>, Device>
       this->m_impl.template writePacket<Unaligned>(inputIndices[0], x);
     }
     else {
-      EIGEN_ALIGN_MAX Scalar values[PacketSize];
+      alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) Scalar values[PacketSize];
       internal::pstore<Scalar, PacketReturnType>(values, x);
       this->m_impl.coeffRef(inputIndices[0]) = values[0];
       this->m_impl.coeffRef(inputIndices[1]) = values[PacketSize-1];

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorTrace.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorTrace.h
@@ -239,7 +239,7 @@ struct TensorEvaluator<const TensorTraceOp<Dims, ArgType>, Device>
     EIGEN_STATIC_ASSERT((PacketSize > 1), YOU_MADE_A_PROGRAMMING_MISTAKE);
     eigen_assert(index + PacketSize - 1 < dimensions().TotalSize());
 
-    EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
     for (int i = 0; i < PacketSize; ++i) {
         values[i] = coeff(index + i);
     }

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorVolumePatch.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorVolumePatch.h
@@ -558,7 +558,7 @@ struct TensorEvaluator<const TensorVolumePatchOp<Planes, Rows, Cols, ArgType>, D
  protected:
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE PacketReturnType packetWithPossibleZero(Index index) const
   {
-    EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) typename internal::remove_const<CoeffReturnType>::type values[PacketSize];
     for (int i = 0; i < PacketSize; ++i) {
       values[i] = coeff(index+i);
     }

--- a/unsupported/test/cxx11_tensor_random.cpp
+++ b/unsupported/test/cxx11_tensor_random.cpp
@@ -51,7 +51,7 @@ struct MyGenerator {
   internal::packet_traits<int>::type packetOp(
       Eigen::DenseIndex packet_location, Eigen::DenseIndex /*unused*/ = 0) const {
     const int packetSize = internal::packet_traits<int>::size;
-    EIGEN_ALIGN_MAX int values[packetSize];
+    alignas(EIGEN_MAX_STATIC_ALIGN_BYTES) int values[packetSize];
     for (int i = 0; i < packetSize; ++i) {
       values[i] = static_cast<int>(3 * (packet_location + i));
     }


### PR DESCRIPTION
## Summary
- use `alignas` in architecture-specific code and tests
- redefine alignment macros to use `alignas`
- document that `EIGEN_ALIGN16` is deprecated

## Testing
- `pre-commit` *(fails: `pre-commit: command not found`)*