### PR TITLE
Remove EIGEN_CONSTEXPR macro

### DIFF
--- a/Eigen/src/Core/util/Macros.h
+++ b/Eigen/src/Core/util/Macros.h
@@ -448,24 +448,9 @@
 #endif
 #endif
 
-// Does the compiler fully support const expressions? (as in c++14)
+// Constexpr support is required by Eigen's C++14 minimum baseline
 #ifndef EIGEN_HAS_CONSTEXPR
-
-#if defined(EIGEN_CUDACC)
-// Const expressions are supported provided that c++11 is enabled and we're using either clang or nvcc 7.5 or above
-#if EIGEN_MAX_CPP_VER>=14 && (__cplusplus > 199711L && (EIGEN_COMP_CLANG || EIGEN_CUDACC_VER >= 70500))
-  #define EIGEN_HAS_CONSTEXPR 1
-#endif
-#elif EIGEN_MAX_CPP_VER>=14 && (__has_feature(cxx_relaxed_constexpr) || (defined(__cplusplus) && __cplusplus >= 201402L) || \
-  (EIGEN_GNUC_AT_LEAST(4,8) && (__cplusplus > 199711L)) || \
-  (EIGEN_COMP_CLANG >= 306 && (__cplusplus > 199711L)))
 #define EIGEN_HAS_CONSTEXPR 1
-#endif
-
-#ifndef EIGEN_HAS_CONSTEXPR
-#define EIGEN_HAS_CONSTEXPR 0
-#endif
-
 #endif
 
 // Does the compiler support C++11 math?

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorIndexList.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorIndexList.h
@@ -674,47 +674,47 @@ struct index_pair_second_statically_eq_impl {
 namespace Eigen {
 namespace internal {
 template <typename T>
-static EIGEN_DEVICE_FUNC EIGEN_CONSTEXPR bool index_known_statically(DenseIndex i) {
+static EIGEN_DEVICE_FUNC constexpr bool index_known_statically(DenseIndex i) {
   return index_known_statically_impl<T>::run(i);
 }
 
 template <typename T>
-static EIGEN_DEVICE_FUNC EIGEN_CONSTEXPR bool all_indices_known_statically() {
+static EIGEN_DEVICE_FUNC constexpr bool all_indices_known_statically() {
   return all_indices_known_statically_impl<T>::run();
 }
 
 template <typename T>
-static EIGEN_DEVICE_FUNC EIGEN_CONSTEXPR bool indices_statically_known_to_increase() {
+static EIGEN_DEVICE_FUNC constexpr bool indices_statically_known_to_increase() {
   return indices_statically_known_to_increase_impl<T>::run();
 }
 
 template <typename T>
-static EIGEN_DEVICE_FUNC EIGEN_CONSTEXPR bool index_statically_eq(DenseIndex i, DenseIndex value) {
+static EIGEN_DEVICE_FUNC constexpr bool index_statically_eq(DenseIndex i, DenseIndex value) {
   return index_statically_eq_impl<T>::run(i, value);
 }
 
 template <typename T>
-static EIGEN_DEVICE_FUNC EIGEN_CONSTEXPR bool index_statically_ne(DenseIndex i, DenseIndex value) {
+static EIGEN_DEVICE_FUNC constexpr bool index_statically_ne(DenseIndex i, DenseIndex value) {
   return index_statically_ne_impl<T>::run(i, value);
 }
 
 template <typename T>
-static EIGEN_DEVICE_FUNC EIGEN_CONSTEXPR bool index_statically_gt(DenseIndex i, DenseIndex value) {
+static EIGEN_DEVICE_FUNC constexpr bool index_statically_gt(DenseIndex i, DenseIndex value) {
   return index_statically_gt_impl<T>::run(i, value);
 }
 
 template <typename T>
-static EIGEN_DEVICE_FUNC EIGEN_CONSTEXPR bool index_statically_lt(DenseIndex i, DenseIndex value) {
+static EIGEN_DEVICE_FUNC constexpr bool index_statically_lt(DenseIndex i, DenseIndex value) {
   return index_statically_lt_impl<T>::run(i, value);
 }
 
 template <typename T>
-static EIGEN_DEVICE_FUNC EIGEN_CONSTEXPR bool index_pair_first_statically_eq(DenseIndex i, DenseIndex value) {
+static EIGEN_DEVICE_FUNC constexpr bool index_pair_first_statically_eq(DenseIndex i, DenseIndex value) {
   return index_pair_first_statically_eq_impl<T>::run(i, value);
 }
 
 template <typename T>
-static EIGEN_DEVICE_FUNC EIGEN_CONSTEXPR bool index_pair_second_statically_eq(DenseIndex i, DenseIndex value) {
+static EIGEN_DEVICE_FUNC constexpr bool index_pair_second_statically_eq(DenseIndex i, DenseIndex value) {
   return index_pair_second_statically_eq_impl<T>::run(i, value);
 }
 

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorMacros.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorMacros.h
@@ -39,17 +39,8 @@
   #endif
 #endif
 #endif
-
 #define EIGEN_SFINAE_ENABLE_IF( __condition__ ) \
     typename internal::enable_if< ( __condition__ ) , int >::type = 0
-
-
-#if EIGEN_HAS_CONSTEXPR
-#define EIGEN_CONSTEXPR constexpr
-#else
-#define EIGEN_CONSTEXPR
-#endif
-
 
 #if EIGEN_OS_WIN || EIGEN_OS_WIN64
 #define EIGEN_SLEEP(n) Sleep(n)

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorMeta.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorMeta.h
@@ -116,10 +116,10 @@ template <typename U, typename V> struct Tuple {
   typedef U first_type;
   typedef V second_type;
 
-  EIGEN_CONSTEXPR EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+  constexpr EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   Tuple() : first(), second() {}
 
-  EIGEN_CONSTEXPR EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+  constexpr EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   Tuple(const U& f, const V& s) : first(f), second(s) {}
 
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
@@ -141,13 +141,13 @@ template <typename U, typename V> struct Tuple {
 };
 
 template <typename U, typename V>
-EIGEN_CONSTEXPR EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+constexpr EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
 bool operator==(const Tuple<U, V>& x, const Tuple<U, V>& y) {
   return (x.first == y.first && x.second == y.second);
 }
 
 template <typename U, typename V>
-EIGEN_CONSTEXPR EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+constexpr EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
 bool operator!=(const Tuple<U, V>& x, const Tuple<U, V>& y) {
   return !(x == y);
 }
@@ -155,8 +155,8 @@ bool operator!=(const Tuple<U, V>& x, const Tuple<U, V>& y) {
 
 // Can't use std::pairs on cuda devices
 template <typename Idx> struct IndexPair {
-  EIGEN_CONSTEXPR EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE IndexPair() : first(0), second(0) {}
-  EIGEN_CONSTEXPR EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE IndexPair(Idx f, Idx s) : first(f), second(s) {}
+  constexpr EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE IndexPair() : first(0), second(0) {}
+  constexpr EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE IndexPair(Idx f, Idx s) : first(f), second(s) {}
 
   EIGEN_DEVICE_FUNC void set(IndexPair<Idx> val) {
     first = val.first;
@@ -172,19 +172,19 @@ template <typename Idx> struct IndexPair {
 namespace internal {
 
   template<typename IndexType, typename Index, Index... Is>
-  EIGEN_CONSTEXPR EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+  constexpr EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   array<Index, sizeof...(Is)> customIndices2Array(IndexType& idx, numeric_list<Index, Is...>) {
     return { idx[Is]... };
   }
   template<typename IndexType, typename Index>
-  EIGEN_CONSTEXPR EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+  constexpr EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   array<Index, 0> customIndices2Array(IndexType&, numeric_list<Index>) {
     return array<Index, 0>();
   }
 
   /** Make an array (for index/dimensions) out of a custom index */
   template<typename Index, std::size_t NumIndices, typename IndexType>
-  EIGEN_CONSTEXPR EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+  constexpr EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   array<Index, NumIndices> customIndices2Array(IndexType& idx) {
     return customIndices2Array(idx, typename gen_numeric_list<Index, NumIndices>::type{});
   }


### PR DESCRIPTION
## Summary
- remove `EIGEN_CONSTEXPR` macro from `TensorMacros.h`
- use plain `constexpr` in tensor headers
- simplify `EIGEN_HAS_CONSTEXPR` check in `Macros.h`

## Testing
- `tests/run_all.sh`