### PR TITLE
Remove custom binder functors

### DIFF
--- a/Eigen/src/Core/functors/BinaryFunctors.h
+++ b/Eigen/src/Core/functors/BinaryFunctors.h
@@ -16,401 +16,443 @@ namespace internal {
 
 //---------- associative binary functors ----------
 
-template<typename Arg1, typename Arg2>
-struct binary_op_base
-{
-  typedef Arg1 first_argument_type;
-  typedef Arg2 second_argument_type;
+template <typename Arg1, typename Arg2> struct binary_op_base {
+    typedef Arg1 first_argument_type;
+    typedef Arg2 second_argument_type;
 };
 
 /** \internal
-  * \brief Template functor to compute the sum of two scalars
-  *
-  * \sa class CwiseBinaryOp, MatrixBase::operator+, class VectorwiseOp, DenseBase::sum()
-  */
-template<typename LhsScalar,typename RhsScalar>
-struct scalar_sum_op : binary_op_base<LhsScalar,RhsScalar>
-{
-  typedef typename ScalarBinaryOpTraits<LhsScalar,RhsScalar,scalar_sum_op>::ReturnType result_type;
+ * \brief Template functor to compute the sum of two scalars
+ *
+ * \sa class CwiseBinaryOp, MatrixBase::operator+, class VectorwiseOp, DenseBase::sum()
+ */
+template <typename LhsScalar, typename RhsScalar>
+struct scalar_sum_op : binary_op_base<LhsScalar, RhsScalar> {
+    typedef
+        typename ScalarBinaryOpTraits<LhsScalar, RhsScalar, scalar_sum_op>::ReturnType result_type;
 #ifndef EIGEN_SCALAR_BINARY_OP_PLUGIN
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_sum_op)
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_sum_op)
 #else
-  scalar_sum_op() {
+    scalar_sum_op() {
     EIGEN_SCALAR_BINARY_OP_PLUGIN
   }
 #endif
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type operator() (const LhsScalar& a, const RhsScalar& b) const { return a + b; }
-  template<typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet packetOp(const Packet& a, const Packet& b) const
-  { return internal::padd(a,b); }
-  template<typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type predux(const Packet& a) const
-  { return internal::predux(a); }
-};
-template<typename LhsScalar,typename RhsScalar>
-struct functor_traits<scalar_sum_op<LhsScalar,RhsScalar> > {
-  enum {
-    Cost = (NumTraits<LhsScalar>::AddCost+NumTraits<RhsScalar>::AddCost)/2, // rough estimate!
-    PacketAccess = is_same<LhsScalar,RhsScalar>::value && packet_traits<LhsScalar>::HasAdd && packet_traits<RhsScalar>::HasAdd
-    // TODO vectorize mixed sum
-  };
-};
-
-/** \internal
-  * \brief Template specialization to deprecate the summation of boolean expressions.
-  * This is required to solve Bug 426.
-  * \sa DenseBase::count(), DenseBase::any(), ArrayBase::cast(), MatrixBase::cast()
-  */
-template<> struct scalar_sum_op<bool,bool> : scalar_sum_op<int,int> {
-  EIGEN_DEPRECATED
-  scalar_sum_op() {}
-};
-
-
-/** \internal
-  * \brief Template functor to compute the product of two scalars
-  *
-  * \sa class CwiseBinaryOp, Cwise::operator*(), class VectorwiseOp, MatrixBase::redux()
-  */
-template<typename LhsScalar,typename RhsScalar>
-struct scalar_product_op  : binary_op_base<LhsScalar,RhsScalar>
-{
-  typedef typename ScalarBinaryOpTraits<LhsScalar,RhsScalar,scalar_product_op>::ReturnType result_type;
-#ifndef EIGEN_SCALAR_BINARY_OP_PLUGIN
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_product_op)
-#else
-  scalar_product_op() {
-    EIGEN_SCALAR_BINARY_OP_PLUGIN
-  }
-#endif
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type operator() (const LhsScalar& a, const RhsScalar& b) const { return a * b; }
-  template<typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet packetOp(const Packet& a, const Packet& b) const
-  { return internal::pmul(a,b); }
-  template<typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type predux(const Packet& a) const
-  { return internal::predux_mul(a); }
-};
-template<typename LhsScalar,typename RhsScalar>
-struct functor_traits<scalar_product_op<LhsScalar,RhsScalar> > {
-  enum {
-    Cost = (NumTraits<LhsScalar>::MulCost + NumTraits<RhsScalar>::MulCost)/2, // rough estimate!
-    PacketAccess = is_same<LhsScalar,RhsScalar>::value && packet_traits<LhsScalar>::HasMul && packet_traits<RhsScalar>::HasMul
-    // TODO vectorize mixed product
-  };
-};
-
-/** \internal
-  * \brief Template functor to compute the conjugate product of two scalars
-  *
-  * This is a short cut for conj(x) * y which is needed for optimization purpose; in Eigen2 support mode, this becomes x * conj(y)
-  */
-template<typename LhsScalar,typename RhsScalar>
-struct scalar_conj_product_op  : binary_op_base<LhsScalar,RhsScalar>
-{
-
-  enum {
-    Conj = NumTraits<LhsScalar>::IsComplex
-  };
-  
-  typedef typename ScalarBinaryOpTraits<LhsScalar,RhsScalar,scalar_conj_product_op>::ReturnType result_type;
-  
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_conj_product_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type operator() (const LhsScalar& a, const RhsScalar& b) const
-  { return conj_helper<LhsScalar,RhsScalar,Conj,false>().pmul(a,b); }
-  
-  template<typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet packetOp(const Packet& a, const Packet& b) const
-  { return conj_helper<Packet,Packet,Conj,false>().pmul(a,b); }
-};
-template<typename LhsScalar,typename RhsScalar>
-struct functor_traits<scalar_conj_product_op<LhsScalar,RhsScalar> > {
-  enum {
-    Cost = NumTraits<LhsScalar>::MulCost,
-    PacketAccess = internal::is_same<LhsScalar, RhsScalar>::value && packet_traits<LhsScalar>::HasMul
-  };
-};
-
-/** \internal
-  * \brief Template functor to compute the min of two scalars
-  *
-  * \sa class CwiseBinaryOp, MatrixBase::cwiseMin, class VectorwiseOp, MatrixBase::minCoeff()
-  */
-template<typename LhsScalar,typename RhsScalar>
-struct scalar_min_op : binary_op_base<LhsScalar,RhsScalar>
-{
-  typedef typename ScalarBinaryOpTraits<LhsScalar,RhsScalar,scalar_min_op>::ReturnType result_type;
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_min_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type operator() (const LhsScalar& a, const RhsScalar& b) const { return numext::mini(a, b); }
-  template<typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet packetOp(const Packet& a, const Packet& b) const
-  { return internal::pmin(a,b); }
-  template<typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type predux(const Packet& a) const
-  { return internal::predux_min(a); }
-};
-template<typename LhsScalar,typename RhsScalar>
-struct functor_traits<scalar_min_op<LhsScalar,RhsScalar> > {
-  enum {
-    Cost = (NumTraits<LhsScalar>::AddCost+NumTraits<RhsScalar>::AddCost)/2,
-    PacketAccess = internal::is_same<LhsScalar, RhsScalar>::value && packet_traits<LhsScalar>::HasMin
-  };
-};
-
-/** \internal
-  * \brief Template functor to compute the max of two scalars
-  *
-  * \sa class CwiseBinaryOp, MatrixBase::cwiseMax, class VectorwiseOp, MatrixBase::maxCoeff()
-  */
-template<typename LhsScalar,typename RhsScalar>
-struct scalar_max_op  : binary_op_base<LhsScalar,RhsScalar>
-{
-  typedef typename ScalarBinaryOpTraits<LhsScalar,RhsScalar,scalar_max_op>::ReturnType result_type;
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_max_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type operator() (const LhsScalar& a, const RhsScalar& b) const { return numext::maxi(a, b); }
-  template<typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet packetOp(const Packet& a, const Packet& b) const
-  { return internal::pmax(a,b); }
-  template<typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type predux(const Packet& a) const
-  { return internal::predux_max(a); }
-};
-template<typename LhsScalar,typename RhsScalar>
-struct functor_traits<scalar_max_op<LhsScalar,RhsScalar> > {
-  enum {
-    Cost = (NumTraits<LhsScalar>::AddCost+NumTraits<RhsScalar>::AddCost)/2,
-    PacketAccess = internal::is_same<LhsScalar, RhsScalar>::value && packet_traits<LhsScalar>::HasMax
-  };
-};
-
-/** \internal
-  * \brief Template functors for comparison of two scalars
-  * \todo Implement packet-comparisons
-  */
-template<typename LhsScalar, typename RhsScalar, ComparisonName cmp> struct scalar_cmp_op;
-
-template<typename LhsScalar, typename RhsScalar, ComparisonName cmp>
-struct functor_traits<scalar_cmp_op<LhsScalar,RhsScalar, cmp> > {
-  enum {
-    Cost = (NumTraits<LhsScalar>::AddCost+NumTraits<RhsScalar>::AddCost)/2,
-    PacketAccess = false
-  };
-};
-
-template<ComparisonName Cmp, typename LhsScalar, typename RhsScalar>
-struct result_of<scalar_cmp_op<LhsScalar, RhsScalar, Cmp>(LhsScalar,RhsScalar)> {
-  typedef bool type;
-};
-
-
-template<typename LhsScalar, typename RhsScalar>
-struct scalar_cmp_op<LhsScalar,RhsScalar, cmp_EQ> : binary_op_base<LhsScalar,RhsScalar>
-{
-  typedef bool result_type;
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_cmp_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator()(const LhsScalar& a, const RhsScalar& b) const {return a==b;}
-};
-template<typename LhsScalar, typename RhsScalar>
-struct scalar_cmp_op<LhsScalar,RhsScalar, cmp_LT> : binary_op_base<LhsScalar,RhsScalar>
-{
-  typedef bool result_type;
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_cmp_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator()(const LhsScalar& a, const RhsScalar& b) const {return a<b;}
-};
-template<typename LhsScalar, typename RhsScalar>
-struct scalar_cmp_op<LhsScalar,RhsScalar, cmp_LE> : binary_op_base<LhsScalar,RhsScalar>
-{
-  typedef bool result_type;
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_cmp_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator()(const LhsScalar& a, const RhsScalar& b) const {return a<=b;}
-};
-template<typename LhsScalar, typename RhsScalar>
-struct scalar_cmp_op<LhsScalar,RhsScalar, cmp_GT> : binary_op_base<LhsScalar,RhsScalar>
-{
-  typedef bool result_type;
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_cmp_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator()(const LhsScalar& a, const RhsScalar& b) const {return a>b;}
-};
-template<typename LhsScalar, typename RhsScalar>
-struct scalar_cmp_op<LhsScalar,RhsScalar, cmp_GE> : binary_op_base<LhsScalar,RhsScalar>
-{
-  typedef bool result_type;
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_cmp_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator()(const LhsScalar& a, const RhsScalar& b) const {return a>=b;}
-};
-template<typename LhsScalar, typename RhsScalar>
-struct scalar_cmp_op<LhsScalar,RhsScalar, cmp_UNORD> : binary_op_base<LhsScalar,RhsScalar>
-{
-  typedef bool result_type;
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_cmp_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator()(const LhsScalar& a, const RhsScalar& b) const {return !(a<=b || b<=a);}
-};
-template<typename LhsScalar, typename RhsScalar>
-struct scalar_cmp_op<LhsScalar,RhsScalar, cmp_NEQ> : binary_op_base<LhsScalar,RhsScalar>
-{
-  typedef bool result_type;
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_cmp_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator()(const LhsScalar& a, const RhsScalar& b) const {return a!=b;}
-};
-
-
-/** \internal
-  * \brief Template functor to compute the hypot of two scalars
-  *
-  * \sa MatrixBase::stableNorm(), class Redux
-  */
-template<typename Scalar>
-struct scalar_hypot_op<Scalar,Scalar> : binary_op_base<Scalar,Scalar>
-{
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_hypot_op)
-//   typedef typename NumTraits<Scalar>::Real result_type;
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Scalar operator() (const Scalar& _x, const Scalar& _y) const
-  {
-    EIGEN_USING_STD_MATH(sqrt)
-    Scalar p, qp;
-    if(_x>_y)
-    {
-      p = _x;
-      qp = _y / p;
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type operator()(const LhsScalar &a,
+                                                                       const RhsScalar &b) const {
+        return a + b;
     }
-    else
-    {
-      p = _y;
-      qp = _x / p;
+    template <typename Packet>
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet packetOp(const Packet &a,
+                                                                const Packet &b) const {
+        return internal::padd(a, b);
     }
-    return p * sqrt(Scalar(1) + qp*qp);
-  }
+    template <typename Packet>
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type predux(const Packet &a) const {
+        return internal::predux(a);
+    }
 };
-template<typename Scalar>
-struct functor_traits<scalar_hypot_op<Scalar,Scalar> > {
-  enum
-  {
-    Cost = 3 * NumTraits<Scalar>::AddCost +
-           2 * NumTraits<Scalar>::MulCost +
-           2 * scalar_div_cost<Scalar,false>::value,
-    PacketAccess = false
-  };
+template <typename LhsScalar, typename RhsScalar>
+struct functor_traits<scalar_sum_op<LhsScalar, RhsScalar>> {
+    enum {
+        Cost =
+            (NumTraits<LhsScalar>::AddCost + NumTraits<RhsScalar>::AddCost) / 2, // rough estimate!
+        PacketAccess = is_same<LhsScalar, RhsScalar>::value && packet_traits<LhsScalar>::HasAdd &&
+                       packet_traits<RhsScalar>::HasAdd
+        // TODO vectorize mixed sum
+    };
 };
 
 /** \internal
-  * \brief Template functor to compute the pow of two scalars
-  */
-template<typename Scalar, typename Exponent>
-struct scalar_pow_op  : binary_op_base<Scalar,Exponent>
-{
-  typedef typename ScalarBinaryOpTraits<Scalar,Exponent,scalar_pow_op>::ReturnType result_type;
+ * \brief Template specialization to deprecate the summation of boolean expressions.
+ * This is required to solve Bug 426.
+ * \sa DenseBase::count(), DenseBase::any(), ArrayBase::cast(), MatrixBase::cast()
+ */
+template <> struct scalar_sum_op<bool, bool> : scalar_sum_op<int, int> {
+    EIGEN_DEPRECATED
+    scalar_sum_op() {}
+};
+
+/** \internal
+ * \brief Template functor to compute the product of two scalars
+ *
+ * \sa class CwiseBinaryOp, Cwise::operator*(), class VectorwiseOp, MatrixBase::redux()
+ */
+template <typename LhsScalar, typename RhsScalar>
+struct scalar_product_op : binary_op_base<LhsScalar, RhsScalar> {
+    typedef typename ScalarBinaryOpTraits<LhsScalar, RhsScalar, scalar_product_op>::ReturnType
+        result_type;
 #ifndef EIGEN_SCALAR_BINARY_OP_PLUGIN
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_pow_op)
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_product_op)
 #else
-  scalar_pow_op() {
-    typedef Scalar LhsScalar;
-    typedef Exponent RhsScalar;
+    scalar_product_op() {
     EIGEN_SCALAR_BINARY_OP_PLUGIN
   }
 #endif
-  EIGEN_DEVICE_FUNC
-  inline result_type operator() (const Scalar& a, const Exponent& b) const { return numext::pow(a, b); }
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type operator()(const LhsScalar &a,
+                                                                       const RhsScalar &b) const {
+        return a * b;
+    }
+    template <typename Packet>
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet packetOp(const Packet &a,
+                                                                const Packet &b) const {
+        return internal::pmul(a, b);
+    }
+    template <typename Packet>
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type predux(const Packet &a) const {
+        return internal::predux_mul(a);
+    }
 };
-template<typename Scalar, typename Exponent>
-struct functor_traits<scalar_pow_op<Scalar,Exponent> > {
-  enum { Cost = 5 * NumTraits<Scalar>::MulCost, PacketAccess = false };
+template <typename LhsScalar, typename RhsScalar>
+struct functor_traits<scalar_product_op<LhsScalar, RhsScalar>> {
+    enum {
+        Cost =
+            (NumTraits<LhsScalar>::MulCost + NumTraits<RhsScalar>::MulCost) / 2, // rough estimate!
+        PacketAccess = is_same<LhsScalar, RhsScalar>::value && packet_traits<LhsScalar>::HasMul &&
+                       packet_traits<RhsScalar>::HasMul
+        // TODO vectorize mixed product
+    };
 };
 
+/** \internal
+ * \brief Template functor to compute the conjugate product of two scalars
+ *
+ * This is a short cut for conj(x) * y which is needed for optimization purpose; in Eigen2 support
+ * mode, this becomes x * conj(y)
+ */
+template <typename LhsScalar, typename RhsScalar>
+struct scalar_conj_product_op : binary_op_base<LhsScalar, RhsScalar> {
 
+    enum { Conj = NumTraits<LhsScalar>::IsComplex };
+
+    typedef typename ScalarBinaryOpTraits<LhsScalar, RhsScalar, scalar_conj_product_op>::ReturnType
+        result_type;
+
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_conj_product_op)
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type operator()(const LhsScalar &a,
+                                                                       const RhsScalar &b) const {
+        return conj_helper<LhsScalar, RhsScalar, Conj, false>().pmul(a, b);
+    }
+
+    template <typename Packet>
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet packetOp(const Packet &a,
+                                                                const Packet &b) const {
+        return conj_helper<Packet, Packet, Conj, false>().pmul(a, b);
+    }
+};
+template <typename LhsScalar, typename RhsScalar>
+struct functor_traits<scalar_conj_product_op<LhsScalar, RhsScalar>> {
+    enum {
+        Cost = NumTraits<LhsScalar>::MulCost,
+        PacketAccess =
+            internal::is_same<LhsScalar, RhsScalar>::value && packet_traits<LhsScalar>::HasMul
+    };
+};
+
+/** \internal
+ * \brief Template functor to compute the min of two scalars
+ *
+ * \sa class CwiseBinaryOp, MatrixBase::cwiseMin, class VectorwiseOp, MatrixBase::minCoeff()
+ */
+template <typename LhsScalar, typename RhsScalar>
+struct scalar_min_op : binary_op_base<LhsScalar, RhsScalar> {
+    typedef
+        typename ScalarBinaryOpTraits<LhsScalar, RhsScalar, scalar_min_op>::ReturnType result_type;
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_min_op)
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type operator()(const LhsScalar &a,
+                                                                       const RhsScalar &b) const {
+        return numext::mini(a, b);
+    }
+    template <typename Packet>
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet packetOp(const Packet &a,
+                                                                const Packet &b) const {
+        return internal::pmin(a, b);
+    }
+    template <typename Packet>
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type predux(const Packet &a) const {
+        return internal::predux_min(a);
+    }
+};
+template <typename LhsScalar, typename RhsScalar>
+struct functor_traits<scalar_min_op<LhsScalar, RhsScalar>> {
+    enum {
+        Cost = (NumTraits<LhsScalar>::AddCost + NumTraits<RhsScalar>::AddCost) / 2,
+        PacketAccess =
+            internal::is_same<LhsScalar, RhsScalar>::value && packet_traits<LhsScalar>::HasMin
+    };
+};
+
+/** \internal
+ * \brief Template functor to compute the max of two scalars
+ *
+ * \sa class CwiseBinaryOp, MatrixBase::cwiseMax, class VectorwiseOp, MatrixBase::maxCoeff()
+ */
+template <typename LhsScalar, typename RhsScalar>
+struct scalar_max_op : binary_op_base<LhsScalar, RhsScalar> {
+    typedef
+        typename ScalarBinaryOpTraits<LhsScalar, RhsScalar, scalar_max_op>::ReturnType result_type;
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_max_op)
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type operator()(const LhsScalar &a,
+                                                                       const RhsScalar &b) const {
+        return numext::maxi(a, b);
+    }
+    template <typename Packet>
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet packetOp(const Packet &a,
+                                                                const Packet &b) const {
+        return internal::pmax(a, b);
+    }
+    template <typename Packet>
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type predux(const Packet &a) const {
+        return internal::predux_max(a);
+    }
+};
+template <typename LhsScalar, typename RhsScalar>
+struct functor_traits<scalar_max_op<LhsScalar, RhsScalar>> {
+    enum {
+        Cost = (NumTraits<LhsScalar>::AddCost + NumTraits<RhsScalar>::AddCost) / 2,
+        PacketAccess =
+            internal::is_same<LhsScalar, RhsScalar>::value && packet_traits<LhsScalar>::HasMax
+    };
+};
+
+/** \internal
+ * \brief Template functors for comparison of two scalars
+ * \todo Implement packet-comparisons
+ */
+template <typename LhsScalar, typename RhsScalar, ComparisonName cmp> struct scalar_cmp_op;
+
+template <typename LhsScalar, typename RhsScalar, ComparisonName cmp>
+struct functor_traits<scalar_cmp_op<LhsScalar, RhsScalar, cmp>> {
+    enum {
+        Cost = (NumTraits<LhsScalar>::AddCost + NumTraits<RhsScalar>::AddCost) / 2,
+        PacketAccess = false
+    };
+};
+
+template <ComparisonName Cmp, typename LhsScalar, typename RhsScalar>
+struct result_of<scalar_cmp_op<LhsScalar, RhsScalar, Cmp>(LhsScalar, RhsScalar)> {
+    typedef bool type;
+};
+
+template <typename LhsScalar, typename RhsScalar>
+struct scalar_cmp_op<LhsScalar, RhsScalar, cmp_EQ> : binary_op_base<LhsScalar, RhsScalar> {
+    typedef bool result_type;
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_cmp_op)
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator()(const LhsScalar &a,
+                                                          const RhsScalar &b) const {
+        return a == b;
+    }
+};
+template <typename LhsScalar, typename RhsScalar>
+struct scalar_cmp_op<LhsScalar, RhsScalar, cmp_LT> : binary_op_base<LhsScalar, RhsScalar> {
+    typedef bool result_type;
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_cmp_op)
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator()(const LhsScalar &a,
+                                                          const RhsScalar &b) const {
+        return a < b;
+    }
+};
+template <typename LhsScalar, typename RhsScalar>
+struct scalar_cmp_op<LhsScalar, RhsScalar, cmp_LE> : binary_op_base<LhsScalar, RhsScalar> {
+    typedef bool result_type;
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_cmp_op)
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator()(const LhsScalar &a,
+                                                          const RhsScalar &b) const {
+        return a <= b;
+    }
+};
+template <typename LhsScalar, typename RhsScalar>
+struct scalar_cmp_op<LhsScalar, RhsScalar, cmp_GT> : binary_op_base<LhsScalar, RhsScalar> {
+    typedef bool result_type;
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_cmp_op)
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator()(const LhsScalar &a,
+                                                          const RhsScalar &b) const {
+        return a > b;
+    }
+};
+template <typename LhsScalar, typename RhsScalar>
+struct scalar_cmp_op<LhsScalar, RhsScalar, cmp_GE> : binary_op_base<LhsScalar, RhsScalar> {
+    typedef bool result_type;
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_cmp_op)
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator()(const LhsScalar &a,
+                                                          const RhsScalar &b) const {
+        return a >= b;
+    }
+};
+template <typename LhsScalar, typename RhsScalar>
+struct scalar_cmp_op<LhsScalar, RhsScalar, cmp_UNORD> : binary_op_base<LhsScalar, RhsScalar> {
+    typedef bool result_type;
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_cmp_op)
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator()(const LhsScalar &a,
+                                                          const RhsScalar &b) const {
+        return !(a <= b || b <= a);
+    }
+};
+template <typename LhsScalar, typename RhsScalar>
+struct scalar_cmp_op<LhsScalar, RhsScalar, cmp_NEQ> : binary_op_base<LhsScalar, RhsScalar> {
+    typedef bool result_type;
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_cmp_op)
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator()(const LhsScalar &a,
+                                                          const RhsScalar &b) const {
+        return a != b;
+    }
+};
+
+/** \internal
+ * \brief Template functor to compute the hypot of two scalars
+ *
+ * \sa MatrixBase::stableNorm(), class Redux
+ */
+template <typename Scalar> struct scalar_hypot_op<Scalar, Scalar> : binary_op_base<Scalar, Scalar> {
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_hypot_op)
+    //   typedef typename NumTraits<Scalar>::Real result_type;
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Scalar operator()(const Scalar &_x,
+                                                                  const Scalar &_y) const {
+        EIGEN_USING_STD_MATH(sqrt)
+        Scalar p, qp;
+        if (_x > _y) {
+            p = _x;
+            qp = _y / p;
+        } else {
+            p = _y;
+            qp = _x / p;
+        }
+        return p * sqrt(Scalar(1) + qp * qp);
+    }
+};
+template <typename Scalar> struct functor_traits<scalar_hypot_op<Scalar, Scalar>> {
+    enum {
+        Cost = 3 * NumTraits<Scalar>::AddCost + 2 * NumTraits<Scalar>::MulCost +
+               2 * scalar_div_cost<Scalar, false>::value,
+        PacketAccess = false
+    };
+};
+
+/** \internal
+ * \brief Template functor to compute the pow of two scalars
+ */
+template <typename Scalar, typename Exponent>
+struct scalar_pow_op : binary_op_base<Scalar, Exponent> {
+    typedef typename ScalarBinaryOpTraits<Scalar, Exponent, scalar_pow_op>::ReturnType result_type;
+#ifndef EIGEN_SCALAR_BINARY_OP_PLUGIN
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_pow_op)
+#else
+    scalar_pow_op() {
+        typedef Scalar LhsScalar;
+        typedef Exponent RhsScalar;
+        EIGEN_SCALAR_BINARY_OP_PLUGIN
+    }
+#endif
+    EIGEN_DEVICE_FUNC
+    inline result_type operator()(const Scalar &a, const Exponent &b) const {
+        return numext::pow(a, b);
+    }
+};
+template <typename Scalar, typename Exponent>
+struct functor_traits<scalar_pow_op<Scalar, Exponent>> {
+    enum { Cost = 5 * NumTraits<Scalar>::MulCost, PacketAccess = false };
+};
 
 //---------- non associative binary functors ----------
 
 /** \internal
-  * \brief Template functor to compute the difference of two scalars
-  *
-  * \sa class CwiseBinaryOp, MatrixBase::operator-
-  */
-template<typename LhsScalar,typename RhsScalar>
-struct scalar_difference_op : binary_op_base<LhsScalar,RhsScalar>
-{
-  typedef typename ScalarBinaryOpTraits<LhsScalar,RhsScalar,scalar_difference_op>::ReturnType result_type;
+ * \brief Template functor to compute the difference of two scalars
+ *
+ * \sa class CwiseBinaryOp, MatrixBase::operator-
+ */
+template <typename LhsScalar, typename RhsScalar>
+struct scalar_difference_op : binary_op_base<LhsScalar, RhsScalar> {
+    typedef typename ScalarBinaryOpTraits<LhsScalar, RhsScalar, scalar_difference_op>::ReturnType
+        result_type;
 #ifndef EIGEN_SCALAR_BINARY_OP_PLUGIN
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_difference_op)
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_difference_op)
 #else
-  scalar_difference_op() {
+    scalar_difference_op() {
     EIGEN_SCALAR_BINARY_OP_PLUGIN
   }
 #endif
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type operator() (const LhsScalar& a, const RhsScalar& b) const { return a - b; }
-  template<typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet packetOp(const Packet& a, const Packet& b) const
-  { return internal::psub(a,b); }
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type operator()(const LhsScalar &a,
+                                                                       const RhsScalar &b) const {
+        return a - b;
+    }
+    template <typename Packet>
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet packetOp(const Packet &a,
+                                                                const Packet &b) const {
+        return internal::psub(a, b);
+    }
 };
-template<typename LhsScalar,typename RhsScalar>
-struct functor_traits<scalar_difference_op<LhsScalar,RhsScalar> > {
-  enum {
-    Cost = (NumTraits<LhsScalar>::AddCost+NumTraits<RhsScalar>::AddCost)/2,
-    PacketAccess = is_same<LhsScalar,RhsScalar>::value && packet_traits<LhsScalar>::HasSub && packet_traits<RhsScalar>::HasSub
-  };
+template <typename LhsScalar, typename RhsScalar>
+struct functor_traits<scalar_difference_op<LhsScalar, RhsScalar>> {
+    enum {
+        Cost = (NumTraits<LhsScalar>::AddCost + NumTraits<RhsScalar>::AddCost) / 2,
+        PacketAccess = is_same<LhsScalar, RhsScalar>::value && packet_traits<LhsScalar>::HasSub &&
+                       packet_traits<RhsScalar>::HasSub
+    };
 };
 
 /** \internal
-  * \brief Template functor to compute the quotient of two scalars
-  *
-  * \sa class CwiseBinaryOp, Cwise::operator/()
-  */
-template<typename LhsScalar,typename RhsScalar>
-struct scalar_quotient_op  : binary_op_base<LhsScalar,RhsScalar>
-{
-  typedef typename ScalarBinaryOpTraits<LhsScalar,RhsScalar,scalar_quotient_op>::ReturnType result_type;
+ * \brief Template functor to compute the quotient of two scalars
+ *
+ * \sa class CwiseBinaryOp, Cwise::operator/()
+ */
+template <typename LhsScalar, typename RhsScalar>
+struct scalar_quotient_op : binary_op_base<LhsScalar, RhsScalar> {
+    typedef typename ScalarBinaryOpTraits<LhsScalar, RhsScalar, scalar_quotient_op>::ReturnType
+        result_type;
 #ifndef EIGEN_SCALAR_BINARY_OP_PLUGIN
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_quotient_op)
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_quotient_op)
 #else
-  scalar_quotient_op() {
+    scalar_quotient_op() {
     EIGEN_SCALAR_BINARY_OP_PLUGIN
   }
 #endif
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type operator() (const LhsScalar& a, const RhsScalar& b) const { return a / b; }
-  template<typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet packetOp(const Packet& a, const Packet& b) const
-  { return internal::pdiv(a,b); }
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type operator()(const LhsScalar &a,
+                                                                       const RhsScalar &b) const {
+        return a / b;
+    }
+    template <typename Packet>
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet packetOp(const Packet &a,
+                                                                const Packet &b) const {
+        return internal::pdiv(a, b);
+    }
 };
-template<typename LhsScalar,typename RhsScalar>
-struct functor_traits<scalar_quotient_op<LhsScalar,RhsScalar> > {
-  typedef typename scalar_quotient_op<LhsScalar,RhsScalar>::result_type result_type;
-  enum {
-    PacketAccess = is_same<LhsScalar,RhsScalar>::value && packet_traits<LhsScalar>::HasDiv && packet_traits<RhsScalar>::HasDiv,
-    Cost = scalar_div_cost<result_type,PacketAccess>::value
-  };
+template <typename LhsScalar, typename RhsScalar>
+struct functor_traits<scalar_quotient_op<LhsScalar, RhsScalar>> {
+    typedef typename scalar_quotient_op<LhsScalar, RhsScalar>::result_type result_type;
+    enum {
+        PacketAccess = is_same<LhsScalar, RhsScalar>::value && packet_traits<LhsScalar>::HasDiv &&
+                       packet_traits<RhsScalar>::HasDiv,
+        Cost = scalar_div_cost<result_type, PacketAccess>::value
+    };
 };
-
-
 
 /** \internal
-  * \brief Template functor to compute the and of two booleans
-  *
-  * \sa class CwiseBinaryOp, ArrayBase::operator&&
-  */
+ * \brief Template functor to compute the and of two booleans
+ *
+ * \sa class CwiseBinaryOp, ArrayBase::operator&&
+ */
 struct scalar_boolean_and_op {
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_boolean_and_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator() (const bool& a, const bool& b) const { return a && b; }
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_boolean_and_op)
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator()(const bool &a, const bool &b) const {
+        return a && b;
+    }
 };
-template<> struct functor_traits<scalar_boolean_and_op> {
-  enum {
-    Cost = NumTraits<bool>::AddCost,
-    PacketAccess = false
-  };
+template <> struct functor_traits<scalar_boolean_and_op> {
+    enum { Cost = NumTraits<bool>::AddCost, PacketAccess = false };
 };
 
 /** \internal
-  * \brief Template functor to compute the or of two booleans
-  *
-  * \sa class CwiseBinaryOp, ArrayBase::operator||
-  */
+ * \brief Template functor to compute the or of two booleans
+ *
+ * \sa class CwiseBinaryOp, ArrayBase::operator||
+ */
 struct scalar_boolean_or_op {
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_boolean_or_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator() (const bool& a, const bool& b) const { return a || b; }
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_boolean_or_op)
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator()(const bool &a, const bool &b) const {
+        return a || b;
+    }
 };
-template<> struct functor_traits<scalar_boolean_or_op> {
-  enum {
-    Cost = NumTraits<bool>::AddCost,
-    PacketAccess = false
-  };
+template <> struct functor_traits<scalar_boolean_or_op> {
+    enum { Cost = NumTraits<bool>::AddCost, PacketAccess = false };
 };
 
 /** \internal
@@ -419,61 +461,14 @@ template<> struct functor_traits<scalar_boolean_or_op> {
  * \sa class CwiseBinaryOp, ArrayBase::operator^
  */
 struct scalar_boolean_xor_op {
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_boolean_xor_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator() (const bool& a, const bool& b) const { return a ^ b; }
+    EIGEN_EMPTY_STRUCT_CTOR(scalar_boolean_xor_op)
+    EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bool operator()(const bool &a, const bool &b) const {
+        return a ^ b;
+    }
 };
-template<> struct functor_traits<scalar_boolean_xor_op> {
-  enum {
-    Cost = NumTraits<bool>::AddCost,
-    PacketAccess = false
-  };
+template <> struct functor_traits<scalar_boolean_xor_op> {
+    enum { Cost = NumTraits<bool>::AddCost, PacketAccess = false };
 };
-
-
-
-//---------- binary functors bound to a constant, thus appearing as a unary functor ----------
-
-// The following two classes permits to turn any binary functor into a unary one with one argument bound to a constant value.
-// They are analogues to std::binder1st/binder2nd but with the following differences:
-//  - they are compatible with packetOp
-//  - they are portable across C++ versions (the std::binder* are deprecated in C++11)
-template<typename BinaryOp> struct bind1st_op : BinaryOp {
-
-  typedef typename BinaryOp::first_argument_type  first_argument_type;
-  typedef typename BinaryOp::second_argument_type second_argument_type;
-  typedef typename BinaryOp::result_type          result_type;
-
-  bind1st_op(const first_argument_type &val) : m_value(val) {}
-
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type operator() (const second_argument_type& b) const { return BinaryOp::operator()(m_value,b); }
-
-  template<typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet packetOp(const Packet& b) const
-  { return BinaryOp::packetOp(internal::pset1<Packet>(m_value), b); }
-
-  first_argument_type m_value;
-};
-template<typename BinaryOp> struct functor_traits<bind1st_op<BinaryOp> > : functor_traits<BinaryOp> {};
-
-
-template<typename BinaryOp> struct bind2nd_op : BinaryOp {
-
-  typedef typename BinaryOp::first_argument_type  first_argument_type;
-  typedef typename BinaryOp::second_argument_type second_argument_type;
-  typedef typename BinaryOp::result_type          result_type;
-
-  bind2nd_op(const second_argument_type &val) : m_value(val) {}
-
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type operator() (const first_argument_type& a) const { return BinaryOp::operator()(a,m_value); }
-
-  template<typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet packetOp(const Packet& a) const
-  { return BinaryOp::packetOp(a,internal::pset1<Packet>(m_value)); }
-
-  second_argument_type m_value;
-};
-template<typename BinaryOp> struct functor_traits<bind2nd_op<BinaryOp> > : functor_traits<BinaryOp> {};
-
 
 } // end namespace internal
 

--- a/unsupported/Eigen/src/AutoDiff/AutoDiffScalar.h
+++ b/unsupported/Eigen/src/AutoDiff/AutoDiffScalar.h
@@ -14,65 +14,70 @@ namespace Eigen {
 
 namespace internal {
 
-template<typename A, typename B>
-struct make_coherent_impl {
-  static void run(A&, B&) {}
+template <typename A, typename B> struct make_coherent_impl {
+    static void run(A &, B &) {}
 };
 
 // resize a to match b is a.size()==0, and conversely.
-template<typename A, typename B>
-void make_coherent(const A& a, const B&b)
-{
-  make_coherent_impl<A,B>::run(a.const_cast_derived(), b.const_cast_derived());
+template <typename A, typename B> void make_coherent(const A &a, const B &b) {
+    make_coherent_impl<A, B>::run(a.const_cast_derived(), b.const_cast_derived());
 }
 
-template<typename _DerType, bool Enable> struct auto_diff_special_op;
+template <typename _DerType, bool Enable> struct auto_diff_special_op;
 
 } // end namespace internal
 
-template<typename _DerType> class AutoDiffScalar;
+template <typename _DerType> class AutoDiffScalar;
 
-template<typename NewDerType>
-inline AutoDiffScalar<NewDerType> MakeAutoDiffScalar(const typename NewDerType::Scalar& value, const NewDerType &der) {
-  return AutoDiffScalar<NewDerType>(value,der);
+template <typename NewDerType>
+inline AutoDiffScalar<NewDerType> MakeAutoDiffScalar(const typename NewDerType::Scalar &value,
+                                                     const NewDerType &der) {
+    return AutoDiffScalar<NewDerType>(value, der);
 }
 
 /** \class AutoDiffScalar
-  * \brief A scalar type replacement with automatic differentation capability
-  *
-  * \param _DerType the vector type used to store/represent the derivatives. The base scalar type
-  *                 as well as the number of derivatives to compute are determined from this type.
-  *                 Typical choices include, e.g., \c Vector4f for 4 derivatives, or \c VectorXf
-  *                 if the number of derivatives is not known at compile time, and/or, the number
-  *                 of derivatives is large.
-  *                 Note that _DerType can also be a reference (e.g., \c VectorXf&) to wrap a
-  *                 existing vector into an AutoDiffScalar.
-  *                 Finally, _DerType can also be any Eigen compatible expression.
-  *
-  * This class represents a scalar value while tracking its respective derivatives using Eigen's expression
-  * template mechanism.
-  *
-  * It supports the following list of global math function:
-  *  - std::abs, std::sqrt, std::pow, std::exp, std::log, std::sin, std::cos,
-  *  - internal::abs, internal::sqrt, numext::pow, internal::exp, internal::log, internal::sin, internal::cos,
-  *  - internal::conj, internal::real, internal::imag, numext::abs2.
-  *
-  * AutoDiffScalar can be used as the scalar type of an Eigen::Matrix object. However,
-  * in that case, the expression template mechanism only occurs at the top Matrix level,
-  * while derivatives are computed right away.
-  *
-  */
+ * \brief A scalar type replacement with automatic differentation capability
+ *
+ * \param _DerType the vector type used to store/represent the derivatives. The base scalar type
+ *                 as well as the number of derivatives to compute are determined from this type.
+ *                 Typical choices include, e.g., \c Vector4f for 4 derivatives, or \c VectorXf
+ *                 if the number of derivatives is not known at compile time, and/or, the number
+ *                 of derivatives is large.
+ *                 Note that _DerType can also be a reference (e.g., \c VectorXf&) to wrap a
+ *                 existing vector into an AutoDiffScalar.
+ *                 Finally, _DerType can also be any Eigen compatible expression.
+ *
+ * This class represents a scalar value while tracking its respective derivatives using Eigen's
+ * expression template mechanism.
+ *
+ * It supports the following list of global math function:
+ *  - std::abs, std::sqrt, std::pow, std::exp, std::log, std::sin, std::cos,
+ *  - internal::abs, internal::sqrt, numext::pow, internal::exp, internal::log, internal::sin,
+ * internal::cos,
+ *  - internal::conj, internal::real, internal::imag, numext::abs2.
+ *
+ * AutoDiffScalar can be used as the scalar type of an Eigen::Matrix object. However,
+ * in that case, the expression template mechanism only occurs at the top Matrix level,
+ * while derivatives are computed right away.
+ *
+ */
 
-template<typename _DerType>
+template <typename _DerType>
 class AutoDiffScalar
-  : public internal::auto_diff_special_op
-            <_DerType, !internal::is_same<typename internal::traits<typename internal::remove_all<_DerType>::type>::Scalar,
-                                          typename NumTraits<typename internal::traits<typename internal::remove_all<_DerType>::type>::Scalar>::Real>::value>
-{
+    : public internal::auto_diff_special_op<
+          _DerType,
+          !internal::is_same<
+              typename internal::traits<typename internal::remove_all<_DerType>::type>::Scalar,
+              typename NumTraits<typename internal::traits<
+                  typename internal::remove_all<_DerType>::type>::Scalar>::Real>::value> {
   public:
-    typedef internal::auto_diff_special_op
-            <_DerType, !internal::is_same<typename internal::traits<typename internal::remove_all<_DerType>::type>::Scalar,
-                       typename NumTraits<typename internal::traits<typename internal::remove_all<_DerType>::type>::Scalar>::Real>::value> Base;
+    typedef internal::auto_diff_special_op<
+        _DerType,
+        !internal::is_same<
+            typename internal::traits<typename internal::remove_all<_DerType>::type>::Scalar,
+            typename NumTraits<typename internal::traits<
+                typename internal::remove_all<_DerType>::type>::Scalar>::Real>::value>
+        Base;
     typedef typename internal::remove_all<_DerType>::type DerType;
     typedef typename internal::traits<DerType>::Scalar Scalar;
     typedef typename NumTraits<Scalar>::Real Real;
@@ -84,435 +89,491 @@ class AutoDiffScalar
     AutoDiffScalar() {}
 
     /** Constructs an active scalar from its \a value,
-        and initializes the \a nbDer derivatives such that it corresponds to the \a derNumber -th variable */
-    AutoDiffScalar(const Scalar& value, int nbDer, int derNumber)
-      : m_value(value), m_derivatives(DerType::Zero(nbDer))
-    {
-      m_derivatives.coeffRef(derNumber) = Scalar(1);
+        and initializes the \a nbDer derivatives such that it corresponds to the \a derNumber -th
+       variable */
+    AutoDiffScalar(const Scalar &value, int nbDer, int derNumber)
+        : m_value(value), m_derivatives(DerType::Zero(nbDer)) {
+        m_derivatives.coeffRef(derNumber) = Scalar(1);
     }
 
     /** Conversion from a scalar constant to an active scalar.
-      * The derivatives are set to zero. */
-    /*explicit*/ AutoDiffScalar(const Real& value)
-      : m_value(value)
-    {
-      if(m_derivatives.size()>0)
-        m_derivatives.setZero();
+     * The derivatives are set to zero. */
+    /*explicit*/ AutoDiffScalar(const Real &value) : m_value(value) {
+        if (m_derivatives.size() > 0)
+            m_derivatives.setZero();
     }
 
     /** Constructs an active scalar from its \a value and derivatives \a der */
-    AutoDiffScalar(const Scalar& value, const DerType& der)
-      : m_value(value), m_derivatives(der)
-    {}
+    AutoDiffScalar(const Scalar &value, const DerType &der) : m_value(value), m_derivatives(der) {}
 
-    template<typename OtherDerType>
-    AutoDiffScalar(const AutoDiffScalar<OtherDerType>& other
+    template <typename OtherDerType>
+    AutoDiffScalar(
+        const AutoDiffScalar<OtherDerType> &other
 #ifndef EIGEN_PARSED_BY_DOXYGEN
-    , typename internal::enable_if<
-            internal::is_same<Scalar, typename internal::traits<typename internal::remove_all<OtherDerType>::type>::Scalar>::value
-        &&  internal::is_convertible<OtherDerType,DerType>::value , void*>::type = 0
+        ,
+        typename internal::enable_if<
+            internal::is_same<Scalar, typename internal::traits<typename internal::remove_all<
+                                          OtherDerType>::type>::Scalar>::value &&
+                internal::is_convertible<OtherDerType, DerType>::value,
+            void *>::type = 0
 #endif
-    )
-      : m_value(other.value()), m_derivatives(other.derivatives())
-    {}
-
-    friend  std::ostream & operator << (std::ostream & s, const AutoDiffScalar& a)
-    {
-      return s << a.value();
+        )
+        : m_value(other.value()), m_derivatives(other.derivatives()) {
     }
 
-    AutoDiffScalar(const AutoDiffScalar& other)
-      : m_value(other.value()), m_derivatives(other.derivatives())
-    {}
-
-    template<typename OtherDerType>
-    inline AutoDiffScalar& operator=(const AutoDiffScalar<OtherDerType>& other)
-    {
-      m_value = other.value();
-      m_derivatives = other.derivatives();
-      return *this;
+    friend std::ostream &operator<<(std::ostream &s, const AutoDiffScalar &a) {
+        return s << a.value();
     }
 
-    inline AutoDiffScalar& operator=(const AutoDiffScalar& other)
-    {
-      m_value = other.value();
-      m_derivatives = other.derivatives();
-      return *this;
+    AutoDiffScalar(const AutoDiffScalar &other)
+        : m_value(other.value()), m_derivatives(other.derivatives()) {}
+
+    template <typename OtherDerType>
+    inline AutoDiffScalar &operator=(const AutoDiffScalar<OtherDerType> &other) {
+        m_value = other.value();
+        m_derivatives = other.derivatives();
+        return *this;
     }
 
-    inline AutoDiffScalar& operator=(const Scalar& other)
-    {
-      m_value = other;
-      if(m_derivatives.size()>0)
-        m_derivatives.setZero();
-      return *this;
+    inline AutoDiffScalar &operator=(const AutoDiffScalar &other) {
+        m_value = other.value();
+        m_derivatives = other.derivatives();
+        return *this;
     }
 
-//     inline operator const Scalar& () const { return m_value; }
-//     inline operator Scalar& () { return m_value; }
-
-    inline const Scalar& value() const { return m_value; }
-    inline Scalar& value() { return m_value; }
-
-    inline const DerType& derivatives() const { return m_derivatives; }
-    inline DerType& derivatives() { return m_derivatives; }
-
-    inline bool operator< (const Scalar& other) const  { return m_value <  other; }
-    inline bool operator<=(const Scalar& other) const  { return m_value <= other; }
-    inline bool operator> (const Scalar& other) const  { return m_value >  other; }
-    inline bool operator>=(const Scalar& other) const  { return m_value >= other; }
-    inline bool operator==(const Scalar& other) const  { return m_value == other; }
-    inline bool operator!=(const Scalar& other) const  { return m_value != other; }
-
-    friend inline bool operator< (const Scalar& a, const AutoDiffScalar& b) { return a <  b.value(); }
-    friend inline bool operator<=(const Scalar& a, const AutoDiffScalar& b) { return a <= b.value(); }
-    friend inline bool operator> (const Scalar& a, const AutoDiffScalar& b) { return a >  b.value(); }
-    friend inline bool operator>=(const Scalar& a, const AutoDiffScalar& b) { return a >= b.value(); }
-    friend inline bool operator==(const Scalar& a, const AutoDiffScalar& b) { return a == b.value(); }
-    friend inline bool operator!=(const Scalar& a, const AutoDiffScalar& b) { return a != b.value(); }
-
-    template<typename OtherDerType> inline bool operator< (const AutoDiffScalar<OtherDerType>& b) const  { return m_value <  b.value(); }
-    template<typename OtherDerType> inline bool operator<=(const AutoDiffScalar<OtherDerType>& b) const  { return m_value <= b.value(); }
-    template<typename OtherDerType> inline bool operator> (const AutoDiffScalar<OtherDerType>& b) const  { return m_value >  b.value(); }
-    template<typename OtherDerType> inline bool operator>=(const AutoDiffScalar<OtherDerType>& b) const  { return m_value >= b.value(); }
-    template<typename OtherDerType> inline bool operator==(const AutoDiffScalar<OtherDerType>& b) const  { return m_value == b.value(); }
-    template<typename OtherDerType> inline bool operator!=(const AutoDiffScalar<OtherDerType>& b) const  { return m_value != b.value(); }
-
-    inline const AutoDiffScalar<DerType&> operator+(const Scalar& other) const
-    {
-      return AutoDiffScalar<DerType&>(m_value + other, m_derivatives);
+    inline AutoDiffScalar &operator=(const Scalar &other) {
+        m_value = other;
+        if (m_derivatives.size() > 0)
+            m_derivatives.setZero();
+        return *this;
     }
 
-    friend inline const AutoDiffScalar<DerType&> operator+(const Scalar& a, const AutoDiffScalar& b)
-    {
-      return AutoDiffScalar<DerType&>(a + b.value(), b.derivatives());
+    //     inline operator const Scalar& () const { return m_value; }
+    //     inline operator Scalar& () { return m_value; }
+
+    inline const Scalar &value() const {
+        return m_value;
+    }
+    inline Scalar &value() {
+        return m_value;
     }
 
-//     inline const AutoDiffScalar<DerType&> operator+(const Real& other) const
-//     {
-//       return AutoDiffScalar<DerType&>(m_value + other, m_derivatives);
-//     }
-
-//     friend inline const AutoDiffScalar<DerType&> operator+(const Real& a, const AutoDiffScalar& b)
-//     {
-//       return AutoDiffScalar<DerType&>(a + b.value(), b.derivatives());
-//     }
-
-    inline AutoDiffScalar& operator+=(const Scalar& other)
-    {
-      value() += other;
-      return *this;
+    inline const DerType &derivatives() const {
+        return m_derivatives;
+    }
+    inline DerType &derivatives() {
+        return m_derivatives;
     }
 
-    template<typename OtherDerType>
-    inline const AutoDiffScalar<CwiseBinaryOp<internal::scalar_sum_op<Scalar>,const DerType,const typename internal::remove_all<OtherDerType>::type> >
-    operator+(const AutoDiffScalar<OtherDerType>& other) const
-    {
-      internal::make_coherent(m_derivatives, other.derivatives());
-      return AutoDiffScalar<CwiseBinaryOp<internal::scalar_sum_op<Scalar>,const DerType,const typename internal::remove_all<OtherDerType>::type> >(
-        m_value + other.value(),
-        m_derivatives + other.derivatives());
+    inline bool operator<(const Scalar &other) const {
+        return m_value < other;
+    }
+    inline bool operator<=(const Scalar &other) const {
+        return m_value <= other;
+    }
+    inline bool operator>(const Scalar &other) const {
+        return m_value > other;
+    }
+    inline bool operator>=(const Scalar &other) const {
+        return m_value >= other;
+    }
+    inline bool operator==(const Scalar &other) const {
+        return m_value == other;
+    }
+    inline bool operator!=(const Scalar &other) const {
+        return m_value != other;
     }
 
-    template<typename OtherDerType>
-    inline AutoDiffScalar&
-    operator+=(const AutoDiffScalar<OtherDerType>& other)
-    {
-      (*this) = (*this) + other;
-      return *this;
+    friend inline bool operator<(const Scalar &a, const AutoDiffScalar &b) {
+        return a < b.value();
+    }
+    friend inline bool operator<=(const Scalar &a, const AutoDiffScalar &b) {
+        return a <= b.value();
+    }
+    friend inline bool operator>(const Scalar &a, const AutoDiffScalar &b) {
+        return a > b.value();
+    }
+    friend inline bool operator>=(const Scalar &a, const AutoDiffScalar &b) {
+        return a >= b.value();
+    }
+    friend inline bool operator==(const Scalar &a, const AutoDiffScalar &b) {
+        return a == b.value();
+    }
+    friend inline bool operator!=(const Scalar &a, const AutoDiffScalar &b) {
+        return a != b.value();
     }
 
-    inline const AutoDiffScalar<DerType&> operator-(const Scalar& b) const
-    {
-      return AutoDiffScalar<DerType&>(m_value - b, m_derivatives);
+    template <typename OtherDerType>
+    inline bool operator<(const AutoDiffScalar<OtherDerType> &b) const {
+        return m_value < b.value();
+    }
+    template <typename OtherDerType>
+    inline bool operator<=(const AutoDiffScalar<OtherDerType> &b) const {
+        return m_value <= b.value();
+    }
+    template <typename OtherDerType>
+    inline bool operator>(const AutoDiffScalar<OtherDerType> &b) const {
+        return m_value > b.value();
+    }
+    template <typename OtherDerType>
+    inline bool operator>=(const AutoDiffScalar<OtherDerType> &b) const {
+        return m_value >= b.value();
+    }
+    template <typename OtherDerType>
+    inline bool operator==(const AutoDiffScalar<OtherDerType> &b) const {
+        return m_value == b.value();
+    }
+    template <typename OtherDerType>
+    inline bool operator!=(const AutoDiffScalar<OtherDerType> &b) const {
+        return m_value != b.value();
     }
 
-    friend inline const AutoDiffScalar<CwiseUnaryOp<internal::scalar_opposite_op<Scalar>, const DerType> >
-    operator-(const Scalar& a, const AutoDiffScalar& b)
-    {
-      return AutoDiffScalar<CwiseUnaryOp<internal::scalar_opposite_op<Scalar>, const DerType> >
-            (a - b.value(), -b.derivatives());
+    inline const AutoDiffScalar<DerType &> operator+(const Scalar &other) const {
+        return AutoDiffScalar<DerType &>(m_value + other, m_derivatives);
     }
 
-    inline AutoDiffScalar& operator-=(const Scalar& other)
-    {
-      value() -= other;
-      return *this;
+    friend inline const AutoDiffScalar<DerType &> operator+(const Scalar &a,
+                                                            const AutoDiffScalar &b) {
+        return AutoDiffScalar<DerType &>(a + b.value(), b.derivatives());
     }
 
-    template<typename OtherDerType>
-    inline const AutoDiffScalar<CwiseBinaryOp<internal::scalar_difference_op<Scalar>, const DerType,const typename internal::remove_all<OtherDerType>::type> >
-    operator-(const AutoDiffScalar<OtherDerType>& other) const
-    {
-      internal::make_coherent(m_derivatives, other.derivatives());
-      return AutoDiffScalar<CwiseBinaryOp<internal::scalar_difference_op<Scalar>, const DerType,const typename internal::remove_all<OtherDerType>::type> >(
-        m_value - other.value(),
-        m_derivatives - other.derivatives());
+    //     inline const AutoDiffScalar<DerType&> operator+(const Real& other) const
+    //     {
+    //       return AutoDiffScalar<DerType&>(m_value + other, m_derivatives);
+    //     }
+
+    //     friend inline const AutoDiffScalar<DerType&> operator+(const Real& a, const
+    //     AutoDiffScalar& b)
+    //     {
+    //       return AutoDiffScalar<DerType&>(a + b.value(), b.derivatives());
+    //     }
+
+    inline AutoDiffScalar &operator+=(const Scalar &other) {
+        value() += other;
+        return *this;
     }
 
-    template<typename OtherDerType>
-    inline AutoDiffScalar&
-    operator-=(const AutoDiffScalar<OtherDerType>& other)
-    {
-      *this = *this - other;
-      return *this;
+    template <typename OtherDerType>
+    inline const AutoDiffScalar<
+        CwiseBinaryOp<internal::scalar_sum_op<Scalar>, const DerType,
+                      const typename internal::remove_all<OtherDerType>::type>>
+    operator+(const AutoDiffScalar<OtherDerType> &other) const {
+        internal::make_coherent(m_derivatives, other.derivatives());
+        return AutoDiffScalar<
+            CwiseBinaryOp<internal::scalar_sum_op<Scalar>, const DerType,
+                          const typename internal::remove_all<OtherDerType>::type>>(
+            m_value + other.value(), m_derivatives + other.derivatives());
     }
 
-    inline const AutoDiffScalar<CwiseUnaryOp<internal::scalar_opposite_op<Scalar>, const DerType> >
-    operator-() const
-    {
-      return AutoDiffScalar<CwiseUnaryOp<internal::scalar_opposite_op<Scalar>, const DerType> >(
-        -m_value,
-        -m_derivatives);
+    template <typename OtherDerType>
+    inline AutoDiffScalar &operator+=(const AutoDiffScalar<OtherDerType> &other) {
+        (*this) = (*this) + other;
+        return *this;
     }
 
-    inline const AutoDiffScalar<EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(DerType,Scalar,product) >
-    operator*(const Scalar& other) const
-    {
-      return MakeAutoDiffScalar(m_value * other, m_derivatives * other);
+    inline const AutoDiffScalar<DerType &> operator-(const Scalar &b) const {
+        return AutoDiffScalar<DerType &>(m_value - b, m_derivatives);
     }
 
-    friend inline const AutoDiffScalar<EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(DerType,Scalar,product) >
-    operator*(const Scalar& other, const AutoDiffScalar& a)
-    {
-      return MakeAutoDiffScalar(a.value() * other, a.derivatives() * other);
+    friend inline const AutoDiffScalar<
+        CwiseUnaryOp<internal::scalar_opposite_op<Scalar>, const DerType>>
+    operator-(const Scalar &a, const AutoDiffScalar &b) {
+        return AutoDiffScalar<CwiseUnaryOp<internal::scalar_opposite_op<Scalar>, const DerType>>(
+            a - b.value(), -b.derivatives());
     }
 
-//     inline const AutoDiffScalar<typename CwiseUnaryOp<internal::scalar_multiple_op<Real>, DerType>::Type >
-//     operator*(const Real& other) const
-//     {
-//       return AutoDiffScalar<typename CwiseUnaryOp<internal::scalar_multiple_op<Real>, DerType>::Type >(
-//         m_value * other,
-//         (m_derivatives * other));
-//     }
-//
-//     friend inline const AutoDiffScalar<typename CwiseUnaryOp<internal::scalar_multiple_op<Real>, DerType>::Type >
-//     operator*(const Real& other, const AutoDiffScalar& a)
-//     {
-//       return AutoDiffScalar<typename CwiseUnaryOp<internal::scalar_multiple_op<Real>, DerType>::Type >(
-//         a.value() * other,
-//         a.derivatives() * other);
-//     }
-
-    inline const AutoDiffScalar<EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(DerType,Scalar,product) >
-    operator/(const Scalar& other) const
-    {
-      return MakeAutoDiffScalar(m_value / other, (m_derivatives * (Scalar(1)/other)));
+    inline AutoDiffScalar &operator-=(const Scalar &other) {
+        value() -= other;
+        return *this;
     }
 
-    friend inline const AutoDiffScalar<EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(DerType,Scalar,product) >
-    operator/(const Scalar& other, const AutoDiffScalar& a)
-    {
-      return MakeAutoDiffScalar(other / a.value(), a.derivatives() * (Scalar(-other) / (a.value()*a.value())));
+    template <typename OtherDerType>
+    inline const AutoDiffScalar<
+        CwiseBinaryOp<internal::scalar_difference_op<Scalar>, const DerType,
+                      const typename internal::remove_all<OtherDerType>::type>>
+    operator-(const AutoDiffScalar<OtherDerType> &other) const {
+        internal::make_coherent(m_derivatives, other.derivatives());
+        return AutoDiffScalar<
+            CwiseBinaryOp<internal::scalar_difference_op<Scalar>, const DerType,
+                          const typename internal::remove_all<OtherDerType>::type>>(
+            m_value - other.value(), m_derivatives - other.derivatives());
     }
 
-//     inline const AutoDiffScalar<typename CwiseUnaryOp<internal::scalar_multiple_op<Real>, DerType>::Type >
-//     operator/(const Real& other) const
-//     {
-//       return AutoDiffScalar<typename CwiseUnaryOp<internal::scalar_multiple_op<Real>, DerType>::Type >(
-//         m_value / other,
-//         (m_derivatives * (Real(1)/other)));
-//     }
-//
-//     friend inline const AutoDiffScalar<typename CwiseUnaryOp<internal::scalar_multiple_op<Real>, DerType>::Type >
-//     operator/(const Real& other, const AutoDiffScalar& a)
-//     {
-//       return AutoDiffScalar<typename CwiseUnaryOp<internal::scalar_multiple_op<Real>, DerType>::Type >(
-//         other / a.value(),
-//         a.derivatives() * (-Real(1)/other));
-//     }
+    template <typename OtherDerType>
+    inline AutoDiffScalar &operator-=(const AutoDiffScalar<OtherDerType> &other) {
+        *this = *this - other;
+        return *this;
+    }
 
-    template<typename OtherDerType>
+    inline const AutoDiffScalar<CwiseUnaryOp<internal::scalar_opposite_op<Scalar>, const DerType>>
+    operator-() const {
+        return AutoDiffScalar<CwiseUnaryOp<internal::scalar_opposite_op<Scalar>, const DerType>>(
+            -m_value, -m_derivatives);
+    }
+
+    inline const AutoDiffScalar<EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(DerType, Scalar, product)>
+    operator*(const Scalar &other) const {
+        return MakeAutoDiffScalar(m_value * other, m_derivatives * other);
+    }
+
+    friend inline const AutoDiffScalar<EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(DerType, Scalar,
+                                                                              product)>
+    operator*(const Scalar &other, const AutoDiffScalar &a) {
+        return MakeAutoDiffScalar(a.value() * other, a.derivatives() * other);
+    }
+
+    //     inline const AutoDiffScalar<typename CwiseUnaryOp<internal::scalar_multiple_op<Real>,
+    //     DerType>::Type > operator*(const Real& other) const
+    //     {
+    //       return AutoDiffScalar<typename CwiseUnaryOp<internal::scalar_multiple_op<Real>,
+    //       DerType>::Type >(
+    //         m_value * other,
+    //         (m_derivatives * other));
+    //     }
+    //
+    //     friend inline const AutoDiffScalar<typename
+    //     CwiseUnaryOp<internal::scalar_multiple_op<Real>, DerType>::Type > operator*(const Real&
+    //     other, const AutoDiffScalar& a)
+    //     {
+    //       return AutoDiffScalar<typename CwiseUnaryOp<internal::scalar_multiple_op<Real>,
+    //       DerType>::Type >(
+    //         a.value() * other,
+    //         a.derivatives() * other);
+    //     }
+
+    inline const AutoDiffScalar<EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(DerType, Scalar, product)>
+    operator/(const Scalar &other) const {
+        return MakeAutoDiffScalar(m_value / other, (m_derivatives * (Scalar(1) / other)));
+    }
+
+    friend inline const AutoDiffScalar<EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(DerType, Scalar,
+                                                                              product)>
+    operator/(const Scalar &other, const AutoDiffScalar &a) {
+        return MakeAutoDiffScalar(other / a.value(),
+                                  a.derivatives() * (Scalar(-other) / (a.value() * a.value())));
+    }
+
+    //     inline const AutoDiffScalar<typename CwiseUnaryOp<internal::scalar_multiple_op<Real>,
+    //     DerType>::Type > operator/(const Real& other) const
+    //     {
+    //       return AutoDiffScalar<typename CwiseUnaryOp<internal::scalar_multiple_op<Real>,
+    //       DerType>::Type >(
+    //         m_value / other,
+    //         (m_derivatives * (Real(1)/other)));
+    //     }
+    //
+    //     friend inline const AutoDiffScalar<typename
+    //     CwiseUnaryOp<internal::scalar_multiple_op<Real>, DerType>::Type > operator/(const Real&
+    //     other, const AutoDiffScalar& a)
+    //     {
+    //       return AutoDiffScalar<typename CwiseUnaryOp<internal::scalar_multiple_op<Real>,
+    //       DerType>::Type >(
+    //         other / a.value(),
+    //         a.derivatives() * (-Real(1)/other));
+    //     }
+
+    template <typename OtherDerType>
     inline const AutoDiffScalar<EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(
-        CwiseBinaryOp<internal::scalar_difference_op<Scalar> EIGEN_COMMA
-          const EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(DerType,Scalar,product) EIGEN_COMMA
-          const EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(typename internal::remove_all<OtherDerType>::type,Scalar,product) >,Scalar,product) >
-    operator/(const AutoDiffScalar<OtherDerType>& other) const
-    {
-      internal::make_coherent(m_derivatives, other.derivatives());
-      return MakeAutoDiffScalar(
-        m_value / other.value(),
-          ((m_derivatives * other.value()) - (other.derivatives() * m_value))
-        * (Scalar(1)/(other.value()*other.value())));
+        CwiseBinaryOp<internal::scalar_difference_op<Scalar> EIGEN_COMMA const
+                          EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(DerType, Scalar, product)
+                              EIGEN_COMMA const EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(
+                                  typename internal::remove_all<OtherDerType>::type, Scalar,
+                                  product)>,
+        Scalar, product)>
+    operator/(const AutoDiffScalar<OtherDerType> &other) const {
+        internal::make_coherent(m_derivatives, other.derivatives());
+        return MakeAutoDiffScalar(
+            m_value / other.value(),
+            ((m_derivatives * other.value()) - (other.derivatives() * m_value)) *
+                (Scalar(1) / (other.value() * other.value())));
     }
 
-    template<typename OtherDerType>
-    inline const AutoDiffScalar<CwiseBinaryOp<internal::scalar_sum_op<Scalar>,
-        const EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(DerType,Scalar,product),
-        const EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(typename internal::remove_all<OtherDerType>::type,Scalar,product) > >
-    operator*(const AutoDiffScalar<OtherDerType>& other) const
-    {
-      internal::make_coherent(m_derivatives, other.derivatives());
-      return MakeAutoDiffScalar(
-        m_value * other.value(),
-        (m_derivatives * other.value()) + (other.derivatives() * m_value));
+    template <typename OtherDerType>
+    inline const AutoDiffScalar<
+        CwiseBinaryOp<internal::scalar_sum_op<Scalar>,
+                      const EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(DerType, Scalar, product),
+                      const EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(
+                          typename internal::remove_all<OtherDerType>::type, Scalar, product)>>
+    operator*(const AutoDiffScalar<OtherDerType> &other) const {
+        internal::make_coherent(m_derivatives, other.derivatives());
+        return MakeAutoDiffScalar(m_value * other.value(), (m_derivatives * other.value()) +
+                                                               (other.derivatives() * m_value));
     }
 
-    inline AutoDiffScalar& operator*=(const Scalar& other)
-    {
-      *this = *this * other;
-      return *this;
+    inline AutoDiffScalar &operator*=(const Scalar &other) {
+        *this = *this * other;
+        return *this;
     }
 
-    template<typename OtherDerType>
-    inline AutoDiffScalar& operator*=(const AutoDiffScalar<OtherDerType>& other)
-    {
-      *this = *this * other;
-      return *this;
+    template <typename OtherDerType>
+    inline AutoDiffScalar &operator*=(const AutoDiffScalar<OtherDerType> &other) {
+        *this = *this * other;
+        return *this;
     }
 
-    inline AutoDiffScalar& operator/=(const Scalar& other)
-    {
-      *this = *this / other;
-      return *this;
+    inline AutoDiffScalar &operator/=(const Scalar &other) {
+        *this = *this / other;
+        return *this;
     }
 
-    template<typename OtherDerType>
-    inline AutoDiffScalar& operator/=(const AutoDiffScalar<OtherDerType>& other)
-    {
-      *this = *this / other;
-      return *this;
+    template <typename OtherDerType>
+    inline AutoDiffScalar &operator/=(const AutoDiffScalar<OtherDerType> &other) {
+        *this = *this / other;
+        return *this;
     }
 
   protected:
     Scalar m_value;
     DerType m_derivatives;
-
 };
 
 namespace internal {
 
-template<typename _DerType>
+template <typename _DerType>
 struct auto_diff_special_op<_DerType, true>
 //   : auto_diff_scalar_op<_DerType, typename NumTraits<Scalar>::Real,
 //                            is_same<Scalar,typename NumTraits<Scalar>::Real>::value>
 {
-  typedef typename remove_all<_DerType>::type DerType;
-  typedef typename traits<DerType>::Scalar Scalar;
-  typedef typename NumTraits<Scalar>::Real Real;
+    typedef typename remove_all<_DerType>::type DerType;
+    typedef typename traits<DerType>::Scalar Scalar;
+    typedef typename NumTraits<Scalar>::Real Real;
 
-//   typedef auto_diff_scalar_op<_DerType, typename NumTraits<Scalar>::Real,
-//                            is_same<Scalar,typename NumTraits<Scalar>::Real>::value> Base;
+    //   typedef auto_diff_scalar_op<_DerType, typename NumTraits<Scalar>::Real,
+    //                            is_same<Scalar,typename NumTraits<Scalar>::Real>::value> Base;
 
-//   using Base::operator+;
-//   using Base::operator+=;
-//   using Base::operator-;
-//   using Base::operator-=;
-//   using Base::operator*;
-//   using Base::operator*=;
+    //   using Base::operator+;
+    //   using Base::operator+=;
+    //   using Base::operator-;
+    //   using Base::operator-=;
+    //   using Base::operator*;
+    //   using Base::operator*=;
 
-  const AutoDiffScalar<_DerType>& derived() const { return *static_cast<const AutoDiffScalar<_DerType>*>(this); }
-  AutoDiffScalar<_DerType>& derived() { return *static_cast<AutoDiffScalar<_DerType>*>(this); }
+    const AutoDiffScalar<_DerType> &derived() const {
+        return *static_cast<const AutoDiffScalar<_DerType> *>(this);
+    }
+    AutoDiffScalar<_DerType> &derived() {
+        return *static_cast<AutoDiffScalar<_DerType> *>(this);
+    }
 
+    inline const AutoDiffScalar<DerType &> operator+(const Real &other) const {
+        return AutoDiffScalar<DerType &>(derived().value() + other, derived().derivatives());
+    }
 
-  inline const AutoDiffScalar<DerType&> operator+(const Real& other) const
-  {
-    return AutoDiffScalar<DerType&>(derived().value() + other, derived().derivatives());
-  }
+    friend inline const AutoDiffScalar<DerType &> operator+(const Real &a,
+                                                            const AutoDiffScalar<_DerType> &b) {
+        return AutoDiffScalar<DerType &>(a + b.value(), b.derivatives());
+    }
 
-  friend inline const AutoDiffScalar<DerType&> operator+(const Real& a, const AutoDiffScalar<_DerType>& b)
-  {
-    return AutoDiffScalar<DerType&>(a + b.value(), b.derivatives());
-  }
+    inline AutoDiffScalar<_DerType> &operator+=(const Real &other) {
+        derived().value() += other;
+        return derived();
+    }
 
-  inline AutoDiffScalar<_DerType>& operator+=(const Real& other)
-  {
-    derived().value() += other;
-    return derived();
-  }
+    inline const AutoDiffScalar<typename CwiseUnaryOp<struct TimesRight, DerType>::Type>
+    operator*(const Real &other) const {
+        struct TimesRight {
+            Real c;
+            EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar operator()(const Scalar &a) const {
+                auto f = [this](const Scalar &x) {
+                    return internal::scalar_product_op<Scalar, Real>()(x, c);
+                };
+                return f(a);
+            }
+            template <typename Packet>
+            EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet packetOp(const Packet &a) const {
+                internal::scalar_product_op<Scalar, Real> op;
+                return op.packetOp(a, internal::pset1<Packet>(c));
+            }
+        };
+        return AutoDiffScalar<typename CwiseUnaryOp<TimesRight, DerType>::Type>(
+            derived().value() * other, derived().derivatives() * other);
+    }
 
+    friend inline const AutoDiffScalar<typename CwiseUnaryOp<struct TimesLeft, DerType>::Type>
+    operator*(const Real &other, const AutoDiffScalar<_DerType> &a) {
+        struct TimesLeft {
+            Real c;
+            EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar operator()(const Scalar &b) const {
+                auto f = std::bind_front(internal::scalar_product_op<Real, Scalar>(), c);
+                return f(b);
+            }
+            template <typename Packet>
+            EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet packetOp(const Packet &b) const {
+                internal::scalar_product_op<Real, Scalar> op;
+                return op.packetOp(internal::pset1<Packet>(c), b);
+            }
+        };
+        return AutoDiffScalar<typename CwiseUnaryOp<TimesLeft, DerType>::Type>(
+            a.value() * other, a.derivatives() * other);
+    }
 
-  inline const AutoDiffScalar<typename CwiseUnaryOp<bind2nd_op<scalar_product_op<Scalar,Real> >, DerType>::Type >
-  operator*(const Real& other) const
-  {
-    return AutoDiffScalar<typename CwiseUnaryOp<bind2nd_op<scalar_product_op<Scalar,Real> >, DerType>::Type >(
-      derived().value() * other,
-      derived().derivatives() * other);
-  }
-
-  friend inline const AutoDiffScalar<typename CwiseUnaryOp<bind1st_op<scalar_product_op<Real,Scalar> >, DerType>::Type >
-  operator*(const Real& other, const AutoDiffScalar<_DerType>& a)
-  {
-    return AutoDiffScalar<typename CwiseUnaryOp<bind1st_op<scalar_product_op<Real,Scalar> >, DerType>::Type >(
-      a.value() * other,
-      a.derivatives() * other);
-  }
-
-  inline AutoDiffScalar<_DerType>& operator*=(const Scalar& other)
-  {
-    *this = *this * other;
-    return derived();
-  }
+    inline AutoDiffScalar<_DerType> &operator*=(const Scalar &other) {
+        *this = *this * other;
+        return derived();
+    }
 };
 
-template<typename _DerType>
-struct auto_diff_special_op<_DerType, false>
-{
-  void operator*() const;
-  void operator-() const;
-  void operator+() const;
+template <typename _DerType> struct auto_diff_special_op<_DerType, false> {
+    void operator*() const;
+    void operator-() const;
+    void operator+() const;
 };
 
-template<typename A_Scalar, int A_Rows, int A_Cols, int A_Options, int A_MaxRows, int A_MaxCols, typename B>
+template <typename A_Scalar, int A_Rows, int A_Cols, int A_Options, int A_MaxRows, int A_MaxCols,
+          typename B>
 struct make_coherent_impl<Matrix<A_Scalar, A_Rows, A_Cols, A_Options, A_MaxRows, A_MaxCols>, B> {
-  typedef Matrix<A_Scalar, A_Rows, A_Cols, A_Options, A_MaxRows, A_MaxCols> A;
-  static void run(A& a, B& b) {
-    if((A_Rows==Dynamic || A_Cols==Dynamic) && (a.size()==0))
-    {
-      a.resize(b.size());
-      a.setZero();
+    typedef Matrix<A_Scalar, A_Rows, A_Cols, A_Options, A_MaxRows, A_MaxCols> A;
+    static void run(A &a, B &b) {
+        if ((A_Rows == Dynamic || A_Cols == Dynamic) && (a.size() == 0)) {
+            a.resize(b.size());
+            a.setZero();
+        }
     }
-  }
 };
 
-template<typename A, typename B_Scalar, int B_Rows, int B_Cols, int B_Options, int B_MaxRows, int B_MaxCols>
-struct make_coherent_impl<A, Matrix<B_Scalar, B_Rows, B_Cols, B_Options, B_MaxRows, B_MaxCols> > {
-  typedef Matrix<B_Scalar, B_Rows, B_Cols, B_Options, B_MaxRows, B_MaxCols> B;
-  static void run(A& a, B& b) {
-    if((B_Rows==Dynamic || B_Cols==Dynamic) && (b.size()==0))
-    {
-      b.resize(a.size());
-      b.setZero();
+template <typename A, typename B_Scalar, int B_Rows, int B_Cols, int B_Options, int B_MaxRows,
+          int B_MaxCols>
+struct make_coherent_impl<A, Matrix<B_Scalar, B_Rows, B_Cols, B_Options, B_MaxRows, B_MaxCols>> {
+    typedef Matrix<B_Scalar, B_Rows, B_Cols, B_Options, B_MaxRows, B_MaxCols> B;
+    static void run(A &a, B &b) {
+        if ((B_Rows == Dynamic || B_Cols == Dynamic) && (b.size() == 0)) {
+            b.resize(a.size());
+            b.setZero();
+        }
     }
-  }
 };
 
-template<typename A_Scalar, int A_Rows, int A_Cols, int A_Options, int A_MaxRows, int A_MaxCols,
-         typename B_Scalar, int B_Rows, int B_Cols, int B_Options, int B_MaxRows, int B_MaxCols>
+template <typename A_Scalar, int A_Rows, int A_Cols, int A_Options, int A_MaxRows, int A_MaxCols,
+          typename B_Scalar, int B_Rows, int B_Cols, int B_Options, int B_MaxRows, int B_MaxCols>
 struct make_coherent_impl<Matrix<A_Scalar, A_Rows, A_Cols, A_Options, A_MaxRows, A_MaxCols>,
-                             Matrix<B_Scalar, B_Rows, B_Cols, B_Options, B_MaxRows, B_MaxCols> > {
-  typedef Matrix<A_Scalar, A_Rows, A_Cols, A_Options, A_MaxRows, A_MaxCols> A;
-  typedef Matrix<B_Scalar, B_Rows, B_Cols, B_Options, B_MaxRows, B_MaxCols> B;
-  static void run(A& a, B& b) {
-    if((A_Rows==Dynamic || A_Cols==Dynamic) && (a.size()==0))
-    {
-      a.resize(b.size());
-      a.setZero();
+                          Matrix<B_Scalar, B_Rows, B_Cols, B_Options, B_MaxRows, B_MaxCols>> {
+    typedef Matrix<A_Scalar, A_Rows, A_Cols, A_Options, A_MaxRows, A_MaxCols> A;
+    typedef Matrix<B_Scalar, B_Rows, B_Cols, B_Options, B_MaxRows, B_MaxCols> B;
+    static void run(A &a, B &b) {
+        if ((A_Rows == Dynamic || A_Cols == Dynamic) && (a.size() == 0)) {
+            a.resize(b.size());
+            a.setZero();
+        } else if ((B_Rows == Dynamic || B_Cols == Dynamic) && (b.size() == 0)) {
+            b.resize(a.size());
+            b.setZero();
+        }
     }
-    else if((B_Rows==Dynamic || B_Cols==Dynamic) && (b.size()==0))
-    {
-      b.resize(a.size());
-      b.setZero();
-    }
-  }
 };
 
 } // end namespace internal
 
-template<typename DerType, typename BinOp>
-struct ScalarBinaryOpTraits<AutoDiffScalar<DerType>,typename DerType::Scalar,BinOp>
-{
-  typedef AutoDiffScalar<DerType> ReturnType;
+template <typename DerType, typename BinOp>
+struct ScalarBinaryOpTraits<AutoDiffScalar<DerType>, typename DerType::Scalar, BinOp> {
+    typedef AutoDiffScalar<DerType> ReturnType;
 };
 
-template<typename DerType, typename BinOp>
-struct ScalarBinaryOpTraits<typename DerType::Scalar,AutoDiffScalar<DerType>, BinOp>
-{
-  typedef AutoDiffScalar<DerType> ReturnType;
+template <typename DerType, typename BinOp>
+struct ScalarBinaryOpTraits<typename DerType::Scalar, AutoDiffScalar<DerType>, BinOp> {
+    typedef AutoDiffScalar<DerType> ReturnType;
 };
 
-
-// The following is an attempt to let Eigen's known about expression template, but that's more tricky!
+// The following is an attempt to let Eigen's known about expression template, but that's more
+// tricky!
 
 // template<typename DerType, typename BinOp>
 // struct ScalarBinaryOpTraits<AutoDiffScalar<DerType>,AutoDiffScalar<DerType>, BinOp>
@@ -524,170 +585,174 @@ struct ScalarBinaryOpTraits<typename DerType::Scalar,AutoDiffScalar<DerType>, Bi
 // template<typename DerType1,typename DerType2, typename BinOp>
 // struct ScalarBinaryOpTraits<AutoDiffScalar<DerType1>,AutoDiffScalar<DerType2>, BinOp>
 // {
-//   enum { Defined = 1 };//internal::is_same<typename DerType1::Scalar,typename DerType2::Scalar>::value };
-//   typedef AutoDiffScalar<typename DerType1::PlainObject> ReturnType;
+//   enum { Defined = 1 };//internal::is_same<typename DerType1::Scalar,typename
+//   DerType2::Scalar>::value }; typedef AutoDiffScalar<typename DerType1::PlainObject> ReturnType;
 // };
 
-#define EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(FUNC,CODE) \
-  template<typename DerType> \
-  inline const Eigen::AutoDiffScalar< \
-  EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(typename Eigen::internal::remove_all<DerType>::type, typename Eigen::internal::traits<typename Eigen::internal::remove_all<DerType>::type>::Scalar, product) > \
-  FUNC(const Eigen::AutoDiffScalar<DerType>& x) { \
-    using namespace Eigen; \
-    EIGEN_UNUSED typedef typename Eigen::internal::traits<typename Eigen::internal::remove_all<DerType>::type>::Scalar Scalar; \
-    CODE; \
-  }
+#define EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(FUNC, CODE)                                            \
+    template <typename DerType>                                                                    \
+    inline const Eigen::AutoDiffScalar<EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(                     \
+        typename Eigen::internal::remove_all<DerType>::type,                                       \
+        typename Eigen::internal::traits<                                                          \
+            typename Eigen::internal::remove_all<DerType>::type>::Scalar,                          \
+        product)>                                                                                  \
+    FUNC(const Eigen::AutoDiffScalar<DerType> &x) {                                                \
+        using namespace Eigen;                                                                     \
+        EIGEN_UNUSED typedef typename Eigen::internal::traits<                                     \
+            typename Eigen::internal::remove_all<DerType>::type>::Scalar Scalar;                   \
+        CODE;                                                                                      \
+    }
 
-template<typename DerType>
-inline const AutoDiffScalar<DerType>& conj(const AutoDiffScalar<DerType>& x)  { return x; }
-template<typename DerType>
-inline const AutoDiffScalar<DerType>& real(const AutoDiffScalar<DerType>& x)  { return x; }
-template<typename DerType>
-inline typename DerType::Scalar imag(const AutoDiffScalar<DerType>&)    { return 0.; }
-template<typename DerType, typename T>
-inline AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject> (min)(const AutoDiffScalar<DerType>& x, const T& y) {
-  typedef AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject> ADS;
-  return (x <= y ? ADS(x) : ADS(y));
+template <typename DerType>
+inline const AutoDiffScalar<DerType> &conj(const AutoDiffScalar<DerType> &x) {
+    return x;
 }
-template<typename DerType, typename T>
-inline AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject> (max)(const AutoDiffScalar<DerType>& x, const T& y) {
-  typedef AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject> ADS;
-  return (x >= y ? ADS(x) : ADS(y));
+template <typename DerType>
+inline const AutoDiffScalar<DerType> &real(const AutoDiffScalar<DerType> &x) {
+    return x;
 }
-template<typename DerType, typename T>
-inline AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject> (min)(const T& x, const AutoDiffScalar<DerType>& y) {
-  typedef AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject> ADS;
-  return (x < y ? ADS(x) : ADS(y));
+template <typename DerType> inline typename DerType::Scalar imag(const AutoDiffScalar<DerType> &) {
+    return 0.;
 }
-template<typename DerType, typename T>
-inline AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject> (max)(const T& x, const AutoDiffScalar<DerType>& y) {
-  typedef AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject> ADS;
-  return (x > y ? ADS(x) : ADS(y));
+template <typename DerType, typename T>
+inline AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject>(min)(
+    const AutoDiffScalar<DerType> &x, const T &y) {
+    typedef AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject> ADS;
+    return (x <= y ? ADS(x) : ADS(y));
 }
-template<typename DerType>
-inline AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject> (min)(const AutoDiffScalar<DerType>& x, const AutoDiffScalar<DerType>& y) {
-  return (x.value() < y.value() ? x : y);
+template <typename DerType, typename T>
+inline AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject>(max)(
+    const AutoDiffScalar<DerType> &x, const T &y) {
+    typedef AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject> ADS;
+    return (x >= y ? ADS(x) : ADS(y));
 }
-template<typename DerType>
-inline AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject> (max)(const AutoDiffScalar<DerType>& x, const AutoDiffScalar<DerType>& y) {
-  return (x.value() >= y.value() ? x : y);
+template <typename DerType, typename T>
+inline AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject>(min)(
+    const T &x, const AutoDiffScalar<DerType> &y) {
+    typedef AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject> ADS;
+    return (x < y ? ADS(x) : ADS(y));
 }
-
-
-EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(abs,
-  using std::abs;
-  return Eigen::MakeAutoDiffScalar(abs(x.value()), x.derivatives() * (x.value()<0 ? -1 : 1) );)
-
-EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(abs2,
-  using numext::abs2;
-  return Eigen::MakeAutoDiffScalar(abs2(x.value()), x.derivatives() * (Scalar(2)*x.value()));)
-
-EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(sqrt,
-  using std::sqrt;
-  Scalar sqrtx = sqrt(x.value());
-  return Eigen::MakeAutoDiffScalar(sqrtx,x.derivatives() * (Scalar(0.5) / sqrtx));)
-
-EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(cos,
-  using std::cos;
-  using std::sin;
-  return Eigen::MakeAutoDiffScalar(cos(x.value()), x.derivatives() * (-sin(x.value())));)
-
-EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(sin,
-  using std::sin;
-  using std::cos;
-  return Eigen::MakeAutoDiffScalar(sin(x.value()),x.derivatives() * cos(x.value()));)
-
-EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(exp,
-  using std::exp;
-  Scalar expx = exp(x.value());
-  return Eigen::MakeAutoDiffScalar(expx,x.derivatives() * expx);)
-
-EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(log,
-  using std::log;
-  return Eigen::MakeAutoDiffScalar(log(x.value()),x.derivatives() * (Scalar(1)/x.value()));)
-
-template<typename DerType>
-inline const Eigen::AutoDiffScalar<
-EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(typename internal::remove_all<DerType>::type,typename internal::traits<typename internal::remove_all<DerType>::type>::Scalar,product) >
-pow(const Eigen::AutoDiffScalar<DerType> &x, const typename internal::traits<typename internal::remove_all<DerType>::type>::Scalar &y)
-{
-  using namespace Eigen;
-  using std::pow;
-  return Eigen::MakeAutoDiffScalar(pow(x.value(),y), x.derivatives() * (y * pow(x.value(),y-1)));
+template <typename DerType, typename T>
+inline AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject>(max)(
+    const T &x, const AutoDiffScalar<DerType> &y) {
+    typedef AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject> ADS;
+    return (x > y ? ADS(x) : ADS(y));
+}
+template <typename DerType>
+inline AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject>(min)(
+    const AutoDiffScalar<DerType> &x, const AutoDiffScalar<DerType> &y) {
+    return (x.value() < y.value() ? x : y);
+}
+template <typename DerType>
+inline AutoDiffScalar<typename Eigen::internal::remove_all<DerType>::type::PlainObject>(max)(
+    const AutoDiffScalar<DerType> &x, const AutoDiffScalar<DerType> &y) {
+    return (x.value() >= y.value() ? x : y);
 }
 
+EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(
+    abs, using std::abs;
+    return Eigen::MakeAutoDiffScalar(abs(x.value()), x.derivatives() * (x.value() < 0 ? -1 : 1));)
 
-template<typename DerTypeA,typename DerTypeB>
-inline const AutoDiffScalar<Matrix<typename internal::traits<typename internal::remove_all<DerTypeA>::type>::Scalar,Dynamic,1> >
-atan2(const AutoDiffScalar<DerTypeA>& a, const AutoDiffScalar<DerTypeB>& b)
-{
-  using std::atan2;
-  typedef typename internal::traits<typename internal::remove_all<DerTypeA>::type>::Scalar Scalar;
-  typedef AutoDiffScalar<Matrix<Scalar,Dynamic,1> > PlainADS;
-  PlainADS ret;
-  ret.value() = atan2(a.value(), b.value());
-  
-  Scalar squared_hypot = a.value() * a.value() + b.value() * b.value();
-  
-  // if (squared_hypot==0) the derivation is undefined and the following results in a NaN:
-  ret.derivatives() = (a.derivatives() * b.value() - a.value() * b.derivatives()) / squared_hypot;
+EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(
+    abs2, using numext::abs2;
+    return Eigen::MakeAutoDiffScalar(abs2(x.value()), x.derivatives() * (Scalar(2) * x.value()));)
 
-  return ret;
+EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(
+    sqrt, using std::sqrt; Scalar sqrtx = sqrt(x.value());
+    return Eigen::MakeAutoDiffScalar(sqrtx, x.derivatives() * (Scalar(0.5) / sqrtx));)
+
+EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(
+    cos, using std::cos; using std::sin;
+    return Eigen::MakeAutoDiffScalar(cos(x.value()), x.derivatives() * (-sin(x.value())));)
+
+EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(
+    sin, using std::sin; using std::cos;
+    return Eigen::MakeAutoDiffScalar(sin(x.value()), x.derivatives() * cos(x.value()));)
+
+EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(exp, using std::exp; Scalar expx = exp(x.value());
+                                    return Eigen::MakeAutoDiffScalar(expx, x.derivatives() * expx);)
+
+EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(log, using std::log; return Eigen::MakeAutoDiffScalar(
+                                        log(x.value()), x.derivatives() * (Scalar(1) / x.value()));)
+
+template <typename DerType>
+inline const Eigen::AutoDiffScalar<EIGEN_EXPR_BINARYOP_SCALAR_RETURN_TYPE(
+    typename internal::remove_all<DerType>::type,
+    typename internal::traits<typename internal::remove_all<DerType>::type>::Scalar, product)>
+pow(const Eigen::AutoDiffScalar<DerType> &x,
+    const typename internal::traits<typename internal::remove_all<DerType>::type>::Scalar &y) {
+    using namespace Eigen;
+    using std::pow;
+    return Eigen::MakeAutoDiffScalar(pow(x.value(), y),
+                                     x.derivatives() * (y * pow(x.value(), y - 1)));
 }
 
-EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(tan,
-  using std::tan;
-  using std::cos;
-  return Eigen::MakeAutoDiffScalar(tan(x.value()),x.derivatives() * (Scalar(1)/numext::abs2(cos(x.value()))));)
+template <typename DerTypeA, typename DerTypeB>
+inline const AutoDiffScalar<Matrix<
+    typename internal::traits<typename internal::remove_all<DerTypeA>::type>::Scalar, Dynamic, 1>>
+atan2(const AutoDiffScalar<DerTypeA> &a, const AutoDiffScalar<DerTypeB> &b) {
+    using std::atan2;
+    typedef typename internal::traits<typename internal::remove_all<DerTypeA>::type>::Scalar Scalar;
+    typedef AutoDiffScalar<Matrix<Scalar, Dynamic, 1>> PlainADS;
+    PlainADS ret;
+    ret.value() = atan2(a.value(), b.value());
 
-EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(asin,
-  using std::sqrt;
-  using std::asin;
-  return Eigen::MakeAutoDiffScalar(asin(x.value()),x.derivatives() * (Scalar(1)/sqrt(1-numext::abs2(x.value()))));)
-  
-EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(acos,
-  using std::sqrt;
-  using std::acos;
-  return Eigen::MakeAutoDiffScalar(acos(x.value()),x.derivatives() * (Scalar(-1)/sqrt(1-numext::abs2(x.value()))));)
+    Scalar squared_hypot = a.value() * a.value() + b.value() * b.value();
 
-EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(tanh,
-  using std::cosh;
-  using std::tanh;
-  return Eigen::MakeAutoDiffScalar(tanh(x.value()),x.derivatives() * (Scalar(1)/numext::abs2(cosh(x.value()))));)
+    // if (squared_hypot==0) the derivation is undefined and the following results in a NaN:
+    ret.derivatives() = (a.derivatives() * b.value() - a.value() * b.derivatives()) / squared_hypot;
 
-EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(sinh,
-  using std::sinh;
-  using std::cosh;
-  return Eigen::MakeAutoDiffScalar(sinh(x.value()),x.derivatives() * cosh(x.value()));)
+    return ret;
+}
 
-EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(cosh,
-  using std::sinh;
-  using std::cosh;
-  return Eigen::MakeAutoDiffScalar(cosh(x.value()),x.derivatives() * sinh(x.value()));)
+EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(
+    tan, using std::tan; using std::cos;
+    return Eigen::MakeAutoDiffScalar(tan(x.value()),
+                                     x.derivatives() * (Scalar(1) / numext::abs2(cos(x.value()))));)
+
+EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(
+    asin, using std::sqrt; using std::asin; return Eigen::MakeAutoDiffScalar(
+        asin(x.value()), x.derivatives() * (Scalar(1) / sqrt(1 - numext::abs2(x.value()))));)
+
+EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(
+    acos, using std::sqrt; using std::acos; return Eigen::MakeAutoDiffScalar(
+        acos(x.value()), x.derivatives() * (Scalar(-1) / sqrt(1 - numext::abs2(x.value()))));)
+
+EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(
+    tanh, using std::cosh; using std::tanh; return Eigen::MakeAutoDiffScalar(
+        tanh(x.value()), x.derivatives() * (Scalar(1) / numext::abs2(cosh(x.value()))));)
+
+EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(
+    sinh, using std::sinh; using std::cosh;
+    return Eigen::MakeAutoDiffScalar(sinh(x.value()), x.derivatives() * cosh(x.value()));)
+
+EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY(
+    cosh, using std::sinh; using std::cosh;
+    return Eigen::MakeAutoDiffScalar(cosh(x.value()), x.derivatives() * sinh(x.value()));)
 
 #undef EIGEN_AUTODIFF_DECLARE_GLOBAL_UNARY
 
-template<typename DerType> struct NumTraits<AutoDiffScalar<DerType> >
-  : NumTraits< typename NumTraits<typename internal::remove_all<DerType>::type::Scalar>::Real >
-{
-  typedef typename internal::remove_all<DerType>::type DerTypeCleaned;
-  typedef AutoDiffScalar<Matrix<typename NumTraits<typename DerTypeCleaned::Scalar>::Real,DerTypeCleaned::RowsAtCompileTime,DerTypeCleaned::ColsAtCompileTime,
-                                0, DerTypeCleaned::MaxRowsAtCompileTime, DerTypeCleaned::MaxColsAtCompileTime> > Real;
-  typedef AutoDiffScalar<DerType> NonInteger;
-  typedef AutoDiffScalar<DerType> Nested;
-  typedef typename NumTraits<typename DerTypeCleaned::Scalar>::Literal Literal;
-  enum{
-    RequireInitialization = 1
-  };
+template <typename DerType>
+struct NumTraits<AutoDiffScalar<DerType>>
+    : NumTraits<typename NumTraits<typename internal::remove_all<DerType>::type::Scalar>::Real> {
+    typedef typename internal::remove_all<DerType>::type DerTypeCleaned;
+    typedef AutoDiffScalar<
+        Matrix<typename NumTraits<typename DerTypeCleaned::Scalar>::Real,
+               DerTypeCleaned::RowsAtCompileTime, DerTypeCleaned::ColsAtCompileTime, 0,
+               DerTypeCleaned::MaxRowsAtCompileTime, DerTypeCleaned::MaxColsAtCompileTime>>
+        Real;
+    typedef AutoDiffScalar<DerType> NonInteger;
+    typedef AutoDiffScalar<DerType> Nested;
+    typedef typename NumTraits<typename DerTypeCleaned::Scalar>::Literal Literal;
+    enum { RequireInitialization = 1 };
 };
 
-}
+} // namespace Eigen
 
 namespace std {
 template <typename T>
-class numeric_limits<Eigen::AutoDiffScalar<T> >
-  : public numeric_limits<typename T::Scalar> {};
+class numeric_limits<Eigen::AutoDiffScalar<T>> : public numeric_limits<typename T::Scalar> {};
 
-}  // namespace std
+} // namespace std
 
 #endif // EIGEN_AUTODIFF_SCALAR_H


### PR DESCRIPTION
## Summary
- remove `bind1st_op` and `bind2nd_op` implementations
- replace binder usage with local lambdas/binders in TensorBase and AutoDiffScalar

## Testing
- `pre-commit` *(fails: command not found)*