### PR TITLE
Deprecate EIGEN_ALIGN macros

### DIFF
--- a/Eigen/src/Core/DenseStorage.h
+++ b/Eigen/src/Core/DenseStorage.h
@@ -82,7 +82,7 @@ struct plain_array
 template <typename T, int Size, int MatrixOrArrayOptions>
 struct plain_array<T, Size, MatrixOrArrayOptions, 8>
 {
-  EIGEN_ALIGN_TO_BOUNDARY(8) T array[Size];
+  alignas(8) T array[Size];
 
   EIGEN_DEVICE_FUNC
   plain_array() 
@@ -101,7 +101,7 @@ struct plain_array<T, Size, MatrixOrArrayOptions, 8>
 template <typename T, int Size, int MatrixOrArrayOptions>
 struct plain_array<T, Size, MatrixOrArrayOptions, 16>
 {
-  EIGEN_ALIGN_TO_BOUNDARY(16) T array[Size];
+  alignas(16) T array[Size];
 
   EIGEN_DEVICE_FUNC
   plain_array() 
@@ -120,7 +120,7 @@ struct plain_array<T, Size, MatrixOrArrayOptions, 16>
 template <typename T, int Size, int MatrixOrArrayOptions>
 struct plain_array<T, Size, MatrixOrArrayOptions, 32>
 {
-  EIGEN_ALIGN_TO_BOUNDARY(32) T array[Size];
+  alignas(32) T array[Size];
 
   EIGEN_DEVICE_FUNC
   plain_array() 
@@ -139,7 +139,7 @@ struct plain_array<T, Size, MatrixOrArrayOptions, 32>
 template <typename T, int Size, int MatrixOrArrayOptions>
 struct plain_array<T, Size, MatrixOrArrayOptions, 64>
 {
-  EIGEN_ALIGN_TO_BOUNDARY(64) T array[Size];
+  alignas(64) T array[Size];
 
   EIGEN_DEVICE_FUNC
   plain_array() 

--- a/Eigen/src/Core/util/Macros.h
+++ b/Eigen/src/Core/util/Macros.h
@@ -678,23 +678,9 @@ namespace Eigen {
  * If we made alignment depend on whether or not EIGEN_VECTORIZE is defined, it would be impossible to link
  * vectorized and non-vectorized code.
  */
-#if defined(__cplusplus) && __cplusplus >= 201103L
-  // Prefer the standard alignas specifier when available.
-  // These macros are deprecated and will expand to alignas.
-  #define EIGEN_ALIGN_TO_BOUNDARY(n) alignas(n)
-#else
-  #if (defined EIGEN_CUDACC)
-    #define EIGEN_ALIGN_TO_BOUNDARY(n) __align__(n)
-  #elif EIGEN_COMP_GNUC || EIGEN_COMP_PGI || EIGEN_COMP_IBM || EIGEN_COMP_ARM
-    #define EIGEN_ALIGN_TO_BOUNDARY(n) __attribute__((aligned(n)))
-  #elif EIGEN_COMP_MSVC
-    #define EIGEN_ALIGN_TO_BOUNDARY(n) __declspec(align(n))
-  #elif EIGEN_COMP_SUNCC
-    // FIXME not sure about this one:
-    #define EIGEN_ALIGN_TO_BOUNDARY(n) __attribute__((aligned(n)))
-  #else
-    #error Please tell me what is the equivalent of __attribute__((aligned(n))) for your compiler
-  #endif
+#if 0
+#define EIGEN_ALIGN_TO_BOUNDARY(n) alignas(n)
+#warning "EIGEN_ALIGN_TO_BOUNDARY is deprecated; use alignas"
 #endif
 
 // If the user explicitly disable vectorization, then we also disable alignment
@@ -786,17 +772,7 @@ namespace Eigen {
 // Henceforth, only EIGEN_MAX_STATIC_ALIGN_BYTES should be used.
 
 
-// Shortcuts to EIGEN_ALIGN_TO_BOUNDARY.
-// Deprecated: prefer using the alignas specifier directly.
-#define EIGEN_ALIGN8  EIGEN_ALIGN_TO_BOUNDARY(8)
-#define EIGEN_ALIGN16 EIGEN_ALIGN_TO_BOUNDARY(16)
-#define EIGEN_ALIGN32 EIGEN_ALIGN_TO_BOUNDARY(32)
-#define EIGEN_ALIGN64 EIGEN_ALIGN_TO_BOUNDARY(64)
-#if EIGEN_MAX_STATIC_ALIGN_BYTES>0
-#define EIGEN_ALIGN_MAX EIGEN_ALIGN_TO_BOUNDARY(EIGEN_MAX_STATIC_ALIGN_BYTES)
-#else
-#define EIGEN_ALIGN_MAX
-#endif
+// EIGEN_ALIGN* macros have been removed. Use the standard alignas specifier.
 
 
 // Dynamic alignment control

--- a/doc/A05_PortingFrom2To3.dox
+++ b/doc/A05_PortingFrom2To3.dox
@@ -259,9 +259,8 @@ use it unless you are sure of what you are doing, i.e., you have rigourosly meas
 
 \section AlignMacros Alignment-related macros
 
-The `EIGEN_ALIGN_128` macro was renamed to `EIGEN_ALIGN16` and is now deprecated
-in favor of the C++11 `alignas` specifier. Existing macros expand to `alignas` so
-older code continues to compile.
+The `EIGEN_ALIGN_128` macro was renamed to `EIGEN_ALIGN16` and has been removed.
+Use the C++11 `alignas` specifier directly in your code.
 
 The \link TopicPreprocessorDirectivesPerformance EIGEN_DONT_ALIGN \endlink option still exists in Eigen 3, but it has a new cousin: \link TopicPreprocessorDirectivesPerformance  EIGEN_DONT_ALIGN_STATICALLY.\endlink It allows to get rid of all static alignment issues while keeping alignment of dynamic-size heap-allocated arrays. Vectorization of statically allocated arrays is still preserved (unless you define \link TopicPreprocessorDirectivesPerformance EIGEN_UNALIGNED_VECTORIZE \endlink =0), at the cost of unaligned memory stores.
 

--- a/unsupported/Eigen/CXX11/src/ThreadPool/EventCount.h
+++ b/unsupported/Eigen/CXX11/src/ThreadPool/EventCount.h
@@ -170,7 +170,7 @@ class EventCount {
   class Waiter {
     friend class EventCount;
     // Align to 128 byte boundary to prevent false sharing with other Waiter objects in the same vector.
-    EIGEN_ALIGN_TO_BOUNDARY(128) std::atomic<Waiter*> next;
+    alignas(128) std::atomic<Waiter*> next;
     std::mutex mu;
     std::condition_variable cv;
     uint64_t epoch;


### PR DESCRIPTION
## Summary
- replace uses of `EIGEN_ALIGN_TO_BOUNDARY` with `alignas`
- drop `EIGEN_ALIGN*` macro definitions in `Macros.h`
- update porting documentation

## Testing
- `pre-commit` *(fails: command not found)*