### PR TITLE
Switch to scoped enum for PaddingType

### DIFF
--- a/unsupported/Eigen/CXX11/src/Tensor/TensorBase.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorBase.h
@@ -814,7 +814,7 @@ class TensorBase<Derived, ReadOnlyAccessors>
     extract_image_patches(const Index patch_rows = 1, const Index patch_cols = 1,
                           const Index row_stride = 1, const Index col_stride = 1,
                           const Index in_row_stride = 1, const Index in_col_stride = 1,
-                          const PaddingType padding_type = PADDING_SAME, const Scalar padding_value = Scalar(0)) const {
+                          const PaddingType padding_type = PaddingType::PADDING_SAME, const Scalar padding_value = Scalar(0)) const {
       return TensorImagePatchOp<Dynamic, Dynamic, const Derived>(derived(), patch_rows, patch_cols, row_stride, col_stride,
                                                                  in_row_stride, in_col_stride, 1, 1, padding_type, padding_value);
     }
@@ -837,7 +837,7 @@ class TensorBase<Derived, ReadOnlyAccessors>
     const TensorVolumePatchOp<Dynamic, Dynamic, Dynamic, const Derived>
     extract_volume_patches(const Index patch_planes, const Index patch_rows, const Index patch_cols,
                            const Index plane_stride = 1, const Index row_stride = 1, const Index col_stride = 1,
-                           const PaddingType padding_type = PADDING_SAME, const Scalar padding_value = Scalar(0)) const {
+                           const PaddingType padding_type = PaddingType::PADDING_SAME, const Scalar padding_value = Scalar(0)) const {
       return TensorVolumePatchOp<Dynamic, Dynamic, Dynamic, const Derived>(derived(), patch_planes, patch_rows, patch_cols, plane_stride, row_stride, col_stride, 1, 1, 1, 1, 1, 1, padding_type, padding_value);
     }
 

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorImagePatch.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorImagePatch.h
@@ -92,7 +92,7 @@ class TensorImagePatchOp : public TensorBase<TensorImagePatchOp<Rows, Cols, XprT
                                                            m_row_inflate_strides(row_inflate_strides), m_col_inflate_strides(col_inflate_strides),
                                                            m_padding_explicit(true), m_padding_top(padding_top), m_padding_bottom(padding_bottom),
                                                            m_padding_left(padding_left), m_padding_right(padding_right),
-                                                           m_padding_type(PADDING_VALID), m_padding_value(padding_value) {}
+                                                           m_padding_type(PaddingType::PADDING_VALID), m_padding_value(padding_value) {}
 
 #ifdef EIGEN_USE_SYCL // this is work around for sycl as Eigen could not use c++11 deligate constructor feature
 EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE TensorImagePatchOp(const XprType& expr, DenseIndex patch_rows, DenseIndex patch_cols,
@@ -252,14 +252,14 @@ struct TensorEvaluator<const TensorImagePatchOp<Rows, Cols, ArgType>, Device>
     } else {
       // Computing padding from the type
       switch (op.padding_type()) {
-        case PADDING_VALID:
+        case PaddingType::PADDING_VALID:
           m_outputRows = numext::ceil((m_input_rows_eff - m_patch_rows_eff + 1.f) / static_cast<float>(m_row_strides));
           m_outputCols = numext::ceil((m_input_cols_eff - m_patch_cols_eff + 1.f) / static_cast<float>(m_col_strides));
           // Calculate the padding
           m_rowPaddingTop = numext::maxi<Index>(0, ((m_outputRows - 1) * m_row_strides + m_patch_rows_eff - m_input_rows_eff) / 2);
           m_colPaddingLeft = numext::maxi<Index>(0, ((m_outputCols - 1) * m_col_strides + m_patch_cols_eff - m_input_cols_eff) / 2);
           break;
-        case PADDING_SAME:
+        case PaddingType::PADDING_SAME:
           m_outputRows = numext::ceil(m_input_rows_eff / static_cast<float>(m_row_strides));
           m_outputCols = numext::ceil(m_input_cols_eff / static_cast<float>(m_col_strides));
           // Calculate the padding

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorTraits.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorTraits.h
@@ -272,10 +272,10 @@ struct nested<const TensorRef<PlainObjectType> >
 // the SAME case.
 // When the stride is 1, we have the simplified case R'=R-K+1, C'=C-K+1, Pr=0,
 // Pc=0.
-typedef enum {
+enum class PaddingType {
   PADDING_VALID = 1,
   PADDING_SAME = 2
-} PaddingType;
+};
 
 }  // end namespace Eigen
 

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorVolumePatch.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorVolumePatch.h
@@ -89,7 +89,7 @@ class TensorVolumePatchOp : public TensorBase<TensorVolumePatchOp<Planes, Rows, 
                                                            m_plane_inflate_strides(plane_inflate_strides), m_row_inflate_strides(row_inflate_strides), m_col_inflate_strides(col_inflate_strides),
                                                            m_padding_explicit(true), m_padding_top_z(padding_top_z), m_padding_bottom_z(padding_bottom_z), m_padding_top(padding_top), m_padding_bottom(padding_bottom),
                                                            m_padding_left(padding_left), m_padding_right(padding_right),
-                                                           m_padding_type(PADDING_VALID), m_padding_value(padding_value) {}
+                                                           m_padding_type(PaddingType::PADDING_VALID), m_padding_value(padding_value) {}
 
 #ifdef EIGEN_USE_SYCL // this is work around for sycl as Eigen could not use c++11 deligate constructor feature
 EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE TensorVolumePatchOp(const XprType& expr, DenseIndex patch_planes, DenseIndex patch_rows, DenseIndex patch_cols,
@@ -264,7 +264,7 @@ struct TensorEvaluator<const TensorVolumePatchOp<Planes, Rows, Cols, ArgType>, D
     } else {
       // Computing padding from the type
       switch (op.padding_type()) {
-        case PADDING_VALID:
+        case PaddingType::PADDING_VALID:
           m_outputPlanes = numext::ceil((m_input_planes_eff - m_patch_planes_eff + 1.f) / static_cast<float>(m_plane_strides));
           m_outputRows = numext::ceil((m_input_rows_eff - m_patch_rows_eff + 1.f) / static_cast<float>(m_row_strides));
           m_outputCols = numext::ceil((m_input_cols_eff - m_patch_cols_eff + 1.f) / static_cast<float>(m_col_strides));
@@ -272,7 +272,7 @@ struct TensorEvaluator<const TensorVolumePatchOp<Planes, Rows, Cols, ArgType>, D
           m_rowPaddingTop = 0;
           m_colPaddingLeft = 0;
           break;
-        case PADDING_SAME: {
+        case PaddingType::PADDING_SAME: {
           m_outputPlanes = numext::ceil(m_input_planes_eff / static_cast<float>(m_plane_strides));
           m_outputRows = numext::ceil(m_input_rows_eff / static_cast<float>(m_row_strides));
           m_outputCols = numext::ceil(m_input_cols_eff / static_cast<float>(m_col_strides));

--- a/unsupported/test/cxx11_tensor_image_patch.cpp
+++ b/unsupported/test/cxx11_tensor_image_patch.cpp
@@ -194,7 +194,7 @@ void test_patch_padding_valid()
     tensor.data()[i] = i + 1;
   }
   // ColMajor
-  Tensor<float, 5> result = tensor.extract_image_patches(ksize, ksize, stride, stride, 1, 1, PADDING_VALID);
+  Tensor<float, 5> result = tensor.extract_image_patches(ksize, ksize, stride, stride, 1, 1, PaddingType::PADDING_VALID);
 
   VERIFY_IS_EQUAL(result.dimension(0), input_depth);  // depth
   VERIFY_IS_EQUAL(result.dimension(1), ksize);  // kernel rows
@@ -209,7 +209,7 @@ void test_patch_padding_valid()
   VERIFY_IS_EQUAL(tensor.dimension(2), tensor_row_major.dimension(1));
   VERIFY_IS_EQUAL(tensor.dimension(3), tensor_row_major.dimension(0));
 
-  Tensor<float, 5, RowMajor> result_row_major = tensor_row_major.extract_image_patches(ksize, ksize, stride, stride, 1, 1, PADDING_VALID);
+  Tensor<float, 5, RowMajor> result_row_major = tensor_row_major.extract_image_patches(ksize, ksize, stride, stride, 1, 1, PaddingType::PADDING_VALID);
   VERIFY_IS_EQUAL(result.dimension(0), result_row_major.dimension(4));
   VERIFY_IS_EQUAL(result.dimension(1), result_row_major.dimension(3));
   VERIFY_IS_EQUAL(result.dimension(2), result_row_major.dimension(2));
@@ -267,7 +267,7 @@ void test_patch_padding_valid_same_value()
   // ColMajor
   Tensor<float, 4> tensor(input_depth, input_rows, input_cols, input_batches);
   tensor = tensor.constant(11.0f);
-  Tensor<float, 5> result = tensor.extract_image_patches(ksize, ksize, stride, stride, 1, 1, PADDING_VALID);
+  Tensor<float, 5> result = tensor.extract_image_patches(ksize, ksize, stride, stride, 1, 1, PaddingType::PADDING_VALID);
 
   VERIFY_IS_EQUAL(result.dimension(0), input_depth);  // depth
   VERIFY_IS_EQUAL(result.dimension(1), ksize);  // kernel rows
@@ -282,7 +282,7 @@ void test_patch_padding_valid_same_value()
   VERIFY_IS_EQUAL(tensor.dimension(2), tensor_row_major.dimension(1));
   VERIFY_IS_EQUAL(tensor.dimension(3), tensor_row_major.dimension(0));
 
-  Tensor<float, 5, RowMajor> result_row_major = tensor_row_major.extract_image_patches(ksize, ksize, stride, stride, 1, 1, PADDING_VALID);
+  Tensor<float, 5, RowMajor> result_row_major = tensor_row_major.extract_image_patches(ksize, ksize, stride, stride, 1, 1, PaddingType::PADDING_VALID);
   VERIFY_IS_EQUAL(result.dimension(0), result_row_major.dimension(4));
   VERIFY_IS_EQUAL(result.dimension(1), result_row_major.dimension(3));
   VERIFY_IS_EQUAL(result.dimension(2), result_row_major.dimension(2));
@@ -343,7 +343,7 @@ void test_patch_padding_same()
   for (int i = 0; i < tensor.size(); ++i) {
     tensor.data()[i] = i + 1;
   }
-  Tensor<float, 5> result = tensor.extract_image_patches(ksize, ksize, stride, stride, PADDING_SAME);
+  Tensor<float, 5> result = tensor.extract_image_patches(ksize, ksize, stride, stride, PaddingType::PADDING_SAME);
 
   VERIFY_IS_EQUAL(result.dimension(0), input_depth);  // depth
   VERIFY_IS_EQUAL(result.dimension(1), ksize);  // kernel rows
@@ -358,7 +358,7 @@ void test_patch_padding_same()
   VERIFY_IS_EQUAL(tensor.dimension(2), tensor_row_major.dimension(1));
   VERIFY_IS_EQUAL(tensor.dimension(3), tensor_row_major.dimension(0));
 
-  Tensor<float, 5, RowMajor> result_row_major = tensor_row_major.extract_image_patches(ksize, ksize, stride, stride, PADDING_SAME);
+  Tensor<float, 5, RowMajor> result_row_major = tensor_row_major.extract_image_patches(ksize, ksize, stride, stride, PaddingType::PADDING_SAME);
   VERIFY_IS_EQUAL(result.dimension(0), result_row_major.dimension(4));
   VERIFY_IS_EQUAL(result.dimension(1), result_row_major.dimension(3));
   VERIFY_IS_EQUAL(result.dimension(2), result_row_major.dimension(2));
@@ -423,7 +423,7 @@ void test_patch_padding_same_negative_padding_clip_to_zero() {
     tensor.data()[i] = i + 1;
   }
   Tensor<float, 5> result = tensor.extract_image_patches(
-      ksize, ksize, row_stride, col_stride, 1, 1, PADDING_SAME);
+      ksize, ksize, row_stride, col_stride, 1, 1, PaddingType::PADDING_SAME);
   // row padding will be computed as -2 originally and then be clipped to 0.
   VERIFY_IS_EQUAL(result.coeff(0), 1.0f);
   VERIFY_IS_EQUAL(result.coeff(1), 6.0f);
@@ -444,7 +444,7 @@ void test_patch_padding_same_negative_padding_clip_to_zero() {
 
   Tensor<float, 5, RowMajor> result_row_major =
       tensor_row_major.extract_image_patches(ksize, ksize, row_stride,
-                                             col_stride, 1, 1, PADDING_SAME);
+                                             col_stride, 1, 1, PaddingType::PADDING_SAME);
   VERIFY_IS_EQUAL(result_row_major.coeff(0), 1.0f);
   VERIFY_IS_EQUAL(result_row_major.coeff(1), 6.0f);
   VERIFY_IS_EQUAL(result_row_major.coeff(2), 11.0f);

--- a/unsupported/test/cxx11_tensor_image_patch_sycl.cpp
+++ b/unsupported/test/cxx11_tensor_image_patch_sycl.cpp
@@ -293,7 +293,7 @@ static void test_patch_padding_valid_sycl(const Eigen::SyclDevice& sycl_device){
   size_t patchTensorBuffSize =result_col_major.size()*sizeof(DataType);
   DataType* gpu_data_result_col_major  = static_cast<DataType*>(sycl_device.allocate(patchTensorBuffSize));
   TensorMap<Tensor<DataType, 5, DataLayout,IndexType>> gpu_result_col_major(gpu_data_result_col_major, patchColMajorTensorRange);
-  gpu_result_col_major.device(sycl_device)=gpu_col_major.extract_image_patches(ksize, ksize, stride, stride, 1, 1, PADDING_VALID);
+gpu_result_col_major.device(sycl_device)=gpu_col_major.extract_image_patches(ksize, ksize, stride, stride, 1, 1, PaddingType::PADDING_VALID);
   sycl_device.memcpyDeviceToHost(result_col_major.data(), gpu_data_result_col_major, patchTensorBuffSize);
 
   VERIFY_IS_EQUAL(result_col_major.dimension(0), input_depth);  // depth
@@ -308,7 +308,7 @@ static void test_patch_padding_valid_sycl(const Eigen::SyclDevice& sycl_device){
   patchTensorBuffSize =result_row_major.size()*sizeof(DataType);
   DataType* gpu_data_result_row_major  = static_cast<DataType*>(sycl_device.allocate(patchTensorBuffSize));
   TensorMap<Tensor<DataType, 5, RowMajor,IndexType>> gpu_result_row_major(gpu_data_result_row_major, patchRowMajorTensorRange);
-  gpu_result_row_major.device(sycl_device)=gpu_row_major.extract_image_patches(ksize, ksize, stride, stride, 1, 1, PADDING_VALID);
+gpu_result_row_major.device(sycl_device)=gpu_row_major.extract_image_patches(ksize, ksize, stride, stride, 1, 1, PaddingType::PADDING_VALID);
   sycl_device.memcpyDeviceToHost(result_row_major.data(), gpu_data_result_row_major, patchTensorBuffSize);
 
   VERIFY_IS_EQUAL(result_col_major.dimension(0), result_row_major.dimension(4));
@@ -394,7 +394,7 @@ static void test_patch_padding_valid_same_value_sycl(const Eigen::SyclDevice& sy
   size_t patchTensorBuffSize =result_col_major.size()*sizeof(DataType);
   DataType* gpu_data_result_col_major  = static_cast<DataType*>(sycl_device.allocate(patchTensorBuffSize));
   TensorMap<Tensor<DataType, 5, DataLayout,IndexType>> gpu_result_col_major(gpu_data_result_col_major, patchColMajorTensorRange);
-  gpu_result_col_major.device(sycl_device)=gpu_col_major.extract_image_patches(ksize, ksize, stride, stride, 1, 1, PADDING_VALID);
+gpu_result_col_major.device(sycl_device)=gpu_col_major.extract_image_patches(ksize, ksize, stride, stride, 1, 1, PaddingType::PADDING_VALID);
   sycl_device.memcpyDeviceToHost(result_col_major.data(), gpu_data_result_col_major, patchTensorBuffSize);
 
   VERIFY_IS_EQUAL(result_col_major.dimension(0), input_depth);  // depth
@@ -409,7 +409,7 @@ static void test_patch_padding_valid_same_value_sycl(const Eigen::SyclDevice& sy
   patchTensorBuffSize =result_row_major.size()*sizeof(DataType);
   DataType* gpu_data_result_row_major  = static_cast<DataType*>(sycl_device.allocate(patchTensorBuffSize));
   TensorMap<Tensor<DataType, 5, RowMajor,IndexType>> gpu_result_row_major(gpu_data_result_row_major, patchRowMajorTensorRange);
-  gpu_result_row_major.device(sycl_device)=gpu_row_major.extract_image_patches(ksize, ksize, stride, stride, 1, 1, PADDING_VALID);
+gpu_result_row_major.device(sycl_device)=gpu_row_major.extract_image_patches(ksize, ksize, stride, stride, 1, 1, PaddingType::PADDING_VALID);
   sycl_device.memcpyDeviceToHost(result_row_major.data(), gpu_data_result_row_major, patchTensorBuffSize);
 
   VERIFY_IS_EQUAL(result_col_major.dimension(0), result_row_major.dimension(4));
@@ -497,7 +497,7 @@ Tensor<DataType, 5, DataLayout,IndexType> result_col_major(patchColMajorTensorRa
 size_t patchTensorBuffSize =result_col_major.size()*sizeof(DataType);
 DataType* gpu_data_result_col_major  = static_cast<DataType*>(sycl_device.allocate(patchTensorBuffSize));
 TensorMap<Tensor<DataType, 5, DataLayout,IndexType>> gpu_result_col_major(gpu_data_result_col_major, patchColMajorTensorRange);
-gpu_result_col_major.device(sycl_device)=gpu_col_major.extract_image_patches(ksize, ksize, stride, stride, PADDING_SAME);
+gpu_result_col_major.device(sycl_device)=gpu_col_major.extract_image_patches(ksize, ksize, stride, stride, PaddingType::PADDING_SAME);
 sycl_device.memcpyDeviceToHost(result_col_major.data(), gpu_data_result_col_major, patchTensorBuffSize);
 
 
@@ -514,7 +514,7 @@ sycl_device.memcpyDeviceToHost(result_col_major.data(), gpu_data_result_col_majo
   patchTensorBuffSize =result_row_major.size()*sizeof(DataType);
   DataType* gpu_data_result_row_major  = static_cast<DataType*>(sycl_device.allocate(patchTensorBuffSize));
   TensorMap<Tensor<DataType, 5, RowMajor,IndexType>> gpu_result_row_major(gpu_data_result_row_major, patchRowMajorTensorRange);
-  gpu_result_row_major.device(sycl_device)=gpu_row_major.extract_image_patches(ksize, ksize, stride, stride, PADDING_SAME);
+gpu_result_row_major.device(sycl_device)=gpu_row_major.extract_image_patches(ksize, ksize, stride, stride, PaddingType::PADDING_SAME);
   sycl_device.memcpyDeviceToHost(result_row_major.data(), gpu_data_result_row_major, patchTensorBuffSize);
 
   VERIFY_IS_EQUAL(result_col_major.dimension(0), result_row_major.dimension(4));


### PR DESCRIPTION
## Summary
- use `enum class PaddingType` instead of `typedef enum`
- update tensor code to use scoped form `PaddingType::PADDING_*`
- adjust tests accordingly

## Testing
- `pre-commit` *(fails: command not found)*