### PR TITLE
Remove outdated bind1st_op comment

### DIFF
--- a/Eigen/src/SparseCore/SparseCwiseBinaryOp.h
+++ b/Eigen/src/SparseCore/SparseCwiseBinaryOp.h
@@ -29,8 +29,6 @@ namespace Eigen {
 //  4 - dense op dense     product      dense
 //                         generic      dense
 //
-// TODO to ease compiler job, we could specialize product/quotient with a scalar
-//      and fallback to cwise-unary evaluator using bind1st_op and bind2nd_op.
 
 template<typename BinaryOp, typename Lhs, typename Rhs>
 class CwiseBinaryOpImpl<BinaryOp, Lhs, Rhs, Sparse>


### PR DESCRIPTION
## Summary
- clean up `SparseCwiseBinaryOp.h`
- remove stale reference to `bind1st_op` and `bind2nd_op`

## Testing
- `grep -R "bind1st_op" -n`