### PR TITLE
Add nodiscard to solver returns

### DIFF
--- a/Eigen/src/Cholesky/LDLT.h
+++ b/Eigen/src/Cholesky/LDLT.h
@@ -196,7 +196,7 @@ template<typename _MatrixType, int _UpLo> class LDLT
       * \sa MatrixBase::ldlt(), SelfAdjointView::ldlt()
       */
     template<typename Rhs>
-    inline const Solve<LDLT, Rhs>
+    EIGEN_NODISCARD inline const Solve<LDLT, Rhs>
     solve(const MatrixBase<Rhs>& b) const
     {
       eigen_assert(m_isInitialized && "LDLT is not initialized.");
@@ -209,7 +209,7 @@ template<typename _MatrixType, int _UpLo> class LDLT
     bool solveInPlace(MatrixBase<Derived> &bAndX) const;
 
     template<typename InputType>
-    LDLT& compute(const EigenBase<InputType>& matrix);
+    EIGEN_NODISCARD LDLT& compute(const EigenBase<InputType>& matrix);
 
     /** \returns an estimate of the reciprocal condition number of the matrix of
      *  which \c *this is the LDLT decomposition.

--- a/Eigen/src/Cholesky/LLT.h
+++ b/Eigen/src/Cholesky/LLT.h
@@ -140,7 +140,7 @@ template<typename _MatrixType, int _UpLo> class LLT
       * \sa solveInPlace(), MatrixBase::llt(), SelfAdjointView::llt()
       */
     template<typename Rhs>
-    inline const Solve<LLT, Rhs>
+    EIGEN_NODISCARD inline const Solve<LLT, Rhs>
     solve(const MatrixBase<Rhs>& b) const
     {
       eigen_assert(m_isInitialized && "LLT is not initialized.");
@@ -153,7 +153,7 @@ template<typename _MatrixType, int _UpLo> class LLT
     void solveInPlace(const MatrixBase<Derived> &bAndX) const;
 
     template<typename InputType>
-    LLT& compute(const EigenBase<InputType>& matrix);
+    EIGEN_NODISCARD LLT& compute(const EigenBase<InputType>& matrix);
 
     /** \returns an estimate of the reciprocal condition number of the matrix of
       *  which \c *this is the Cholesky decomposition.

--- a/Eigen/src/CholmodSupport/CholmodSupport.h
+++ b/Eigen/src/CholmodSupport/CholmodSupport.h
@@ -270,7 +270,7 @@ class CholmodBase : public SparseSolverBase<Derived>
     }
 
     /** Computes the sparse Cholesky decomposition of \a matrix */
-    Derived& compute(const MatrixType& matrix)
+    EIGEN_NODISCARD Derived& compute(const MatrixType& matrix)
     {
       analyzePattern(matrix);
       factorize(matrix);

--- a/Eigen/src/Core/SolveTriangular.h
+++ b/Eigen/src/Core/SolveTriangular.h
@@ -184,7 +184,7 @@ EIGEN_DEVICE_FUNC void TriangularViewImpl<MatrixType,Mode,Dense>::solveInPlace(c
 
 template<typename Derived, unsigned int Mode>
 template<int Side, typename Other>
-const internal::triangular_solve_retval<Side,TriangularView<Derived,Mode>,Other>
+EIGEN_NODISCARD const internal::triangular_solve_retval<Side,TriangularView<Derived,Mode>,Other>
 TriangularViewImpl<Derived,Mode,Dense>::solve(const MatrixBase<Other>& other) const
 {
   return internal::triangular_solve_retval<Side,TriangularViewType,Other>(derived(), other.derived());

--- a/Eigen/src/Core/SolverBase.h
+++ b/Eigen/src/Core/SolverBase.h
@@ -69,9 +69,10 @@ class SolverBase : public EigenBase<Derived>
     using Base::derived;
 
     /** \returns an expression of the solution x of \f$ A x = b \f$ using the current decomposition of A.
+      * \warning Discarding the returned expression has no effect.
       */
     template<typename Rhs>
-    inline const Solve<Derived, Rhs>
+    EIGEN_NODISCARD inline const Solve<Derived, Rhs>
     solve(const MatrixBase<Rhs>& b) const
     {
       eigen_assert(derived().rows()==b.rows() && "solve(): invalid number of rows of the right hand side matrix b");

--- a/Eigen/src/Core/TriangularMatrix.h
+++ b/Eigen/src/Core/TriangularMatrix.h
@@ -268,7 +268,7 @@ template<typename _MatrixType, unsigned int _Mode> class TriangularView
 
     template<typename Other>
     EIGEN_DEVICE_FUNC
-    inline const Solve<TriangularView, Other> 
+    EIGEN_NODISCARD inline const Solve<TriangularView, Other>
     solve(const MatrixBase<Other>& other) const
     { return Solve<TriangularView, Other>(*this, other.derived()); }
     

--- a/Eigen/src/Eigenvalues/ComplexEigenSolver.h
+++ b/Eigen/src/Eigenvalues/ComplexEigenSolver.h
@@ -210,7 +210,7 @@ template<typename _MatrixType> class ComplexEigenSolver
       * Output: \verbinclude ComplexEigenSolver_compute.out
       */
     template<typename InputType>
-    ComplexEigenSolver& compute(const EigenBase<InputType>& matrix, bool computeEigenvectors = true);
+    EIGEN_NODISCARD ComplexEigenSolver& compute(const EigenBase<InputType>& matrix, bool computeEigenvectors = true);
 
     /** \brief Reports whether previous computation was successful.
       *

--- a/Eigen/src/Eigenvalues/EigenSolver.h
+++ b/Eigen/src/Eigenvalues/EigenSolver.h
@@ -275,7 +275,7 @@ template<typename _MatrixType> class EigenSolver
       * Output: \verbinclude EigenSolver_compute.out
       */
     template<typename InputType>
-    EigenSolver& compute(const EigenBase<InputType>& matrix, bool computeEigenvectors = true);
+    EIGEN_NODISCARD EigenSolver& compute(const EigenBase<InputType>& matrix, bool computeEigenvectors = true);
 
     /** \returns NumericalIssue if the input contains INF or NaN values or overflow occured. Returns Success otherwise. */
     ComputationInfo info() const

--- a/Eigen/src/Eigenvalues/GeneralizedEigenSolver.h
+++ b/Eigen/src/Eigenvalues/GeneralizedEigenSolver.h
@@ -250,7 +250,7 @@ template<typename _MatrixType> class GeneralizedEigenSolver
       *
       * This method reuses of the allocated data in the GeneralizedEigenSolver object.
       */
-    GeneralizedEigenSolver& compute(const MatrixType& A, const MatrixType& B, bool computeEigenvectors = true);
+    EIGEN_NODISCARD GeneralizedEigenSolver& compute(const MatrixType& A, const MatrixType& B, bool computeEigenvectors = true);
 
     ComputationInfo info() const
     {

--- a/Eigen/src/Eigenvalues/GeneralizedSelfAdjointEigenSolver.h
+++ b/Eigen/src/Eigenvalues/GeneralizedSelfAdjointEigenSolver.h
@@ -150,7 +150,7 @@ class GeneralizedSelfAdjointEigenSolver : public SelfAdjointEigenSolver<_MatrixT
       *
       * \sa GeneralizedSelfAdjointEigenSolver(const MatrixType&, const MatrixType&, int)
       */
-    GeneralizedSelfAdjointEigenSolver& compute(const MatrixType& matA, const MatrixType& matB,
+    EIGEN_NODISCARD GeneralizedSelfAdjointEigenSolver& compute(const MatrixType& matA, const MatrixType& matB,
                                                int options = ComputeEigenvectors|Ax_lBx);
 
   protected:

--- a/Eigen/src/Eigenvalues/HessenbergDecomposition.h
+++ b/Eigen/src/Eigenvalues/HessenbergDecomposition.h
@@ -149,7 +149,7 @@ template<typename _MatrixType> class HessenbergDecomposition
       * Output: \verbinclude HessenbergDecomposition_compute.out
       */
     template<typename InputType>
-    HessenbergDecomposition& compute(const EigenBase<InputType>& matrix)
+    EIGEN_NODISCARD HessenbergDecomposition& compute(const EigenBase<InputType>& matrix)
     {
       m_matrix = matrix.derived();
       if(matrix.rows()<2)

--- a/Eigen/src/Eigenvalues/RealQZ.h
+++ b/Eigen/src/Eigenvalues/RealQZ.h
@@ -157,7 +157,7 @@ namespace Eigen {
        * \param[in]  computeQZ  If false, A and Z are not computed.
        * \returns    Reference to \c *this
        */
-      RealQZ& compute(const MatrixType& A, const MatrixType& B, bool computeQZ = true);
+      EIGEN_NODISCARD RealQZ& compute(const MatrixType& A, const MatrixType& B, bool computeQZ = true);
 
       /** \brief Reports whether previous computation was successful.
        *

--- a/Eigen/src/Eigenvalues/RealSchur.h
+++ b/Eigen/src/Eigenvalues/RealSchur.h
@@ -167,7 +167,7 @@ template<typename _MatrixType> class RealSchur
       * \sa compute(const MatrixType&, bool, Index)
       */
     template<typename InputType>
-    RealSchur& compute(const EigenBase<InputType>& matrix, bool computeU = true);
+    EIGEN_NODISCARD RealSchur& compute(const EigenBase<InputType>& matrix, bool computeU = true);
 
     /** \brief Computes Schur decomposition of a Hessenberg matrix H = Z T Z^T
      *  \param[in] matrixH Matrix in Hessenberg form H
@@ -187,7 +187,7 @@ template<typename _MatrixType> class RealSchur
      * \sa compute(const MatrixType&, bool)
      */
     template<typename HessMatrixType, typename OrthMatrixType>
-    RealSchur& computeFromHessenberg(const HessMatrixType& matrixH, const OrthMatrixType& matrixQ,  bool computeU);
+    EIGEN_NODISCARD RealSchur& computeFromHessenberg(const HessMatrixType& matrixH, const OrthMatrixType& matrixQ,  bool computeU);
     /** \brief Reports whether previous computation was successful.
       *
       * \returns \c Success if computation was succesful, \c NoConvergence otherwise.

--- a/Eigen/src/Eigenvalues/SelfAdjointEigenSolver.h
+++ b/Eigen/src/Eigenvalues/SelfAdjointEigenSolver.h
@@ -200,7 +200,7 @@ template<typename _MatrixType> class SelfAdjointEigenSolver
       */
     template<typename InputType>
     EIGEN_DEVICE_FUNC
-    SelfAdjointEigenSolver& compute(const EigenBase<InputType>& matrix, int options = ComputeEigenvectors);
+    EIGEN_NODISCARD SelfAdjointEigenSolver& compute(const EigenBase<InputType>& matrix, int options = ComputeEigenvectors);
     
     /** \brief Computes eigendecomposition of given matrix using a closed-form algorithm
       *
@@ -221,7 +221,7 @@ template<typename _MatrixType> class SelfAdjointEigenSolver
       * \sa compute(const MatrixType&, int options)
       */
     EIGEN_DEVICE_FUNC
-    SelfAdjointEigenSolver& computeDirect(const MatrixType& matrix, int options = ComputeEigenvectors);
+    EIGEN_NODISCARD SelfAdjointEigenSolver& computeDirect(const MatrixType& matrix, int options = ComputeEigenvectors);
 
     /**
       *\brief Computes the eigen decomposition from a tridiagonal symmetric matrix
@@ -235,7 +235,7 @@ template<typename _MatrixType> class SelfAdjointEigenSolver
       *
       * \sa compute(const MatrixType&, int) for more information
       */
-    SelfAdjointEigenSolver& computeFromTridiagonal(const RealVectorType& diag, const SubDiagonalType& subdiag , int options=ComputeEigenvectors);
+    EIGEN_NODISCARD SelfAdjointEigenSolver& computeFromTridiagonal(const RealVectorType& diag, const SubDiagonalType& subdiag , int options=ComputeEigenvectors);
 
     /** \brief Returns the eigenvectors of given matrix.
       *

--- a/Eigen/src/IterativeLinearSolvers/BasicPreconditioners.h
+++ b/Eigen/src/IterativeLinearSolvers/BasicPreconditioners.h
@@ -79,7 +79,7 @@ class DiagonalPreconditioner
     }
     
     template<typename MatType>
-    DiagonalPreconditioner& compute(const MatType& mat)
+    EIGEN_NODISCARD DiagonalPreconditioner& compute(const MatType& mat)
     {
       return factorize(mat);
     }
@@ -91,7 +91,7 @@ class DiagonalPreconditioner
       x = m_invdiag.array() * b.array() ;
     }
 
-    template<typename Rhs> inline const Solve<DiagonalPreconditioner, Rhs>
+    template<typename Rhs> EIGEN_NODISCARD inline const Solve<DiagonalPreconditioner, Rhs>
     solve(const MatrixBase<Rhs>& b) const
     {
       eigen_assert(m_isInitialized && "DiagonalPreconditioner is not initialized.");
@@ -180,7 +180,7 @@ class LeastSquareDiagonalPreconditioner : public DiagonalPreconditioner<_Scalar>
     }
     
     template<typename MatType>
-    LeastSquareDiagonalPreconditioner& compute(const MatType& mat)
+    EIGEN_NODISCARD LeastSquareDiagonalPreconditioner& compute(const MatType& mat)
     {
       return factorize(mat);
     }
@@ -213,7 +213,7 @@ class IdentityPreconditioner
     IdentityPreconditioner& factorize(const MatrixType& ) { return *this; }
 
     template<typename MatrixType>
-    IdentityPreconditioner& compute(const MatrixType& ) { return *this; }
+    EIGEN_NODISCARD IdentityPreconditioner& compute(const MatrixType& ) { return *this; }
     
     template<typename Rhs>
     inline const Rhs& solve(const Rhs& b) const { return b; }

--- a/Eigen/src/IterativeLinearSolvers/IterativeSolverBase.h
+++ b/Eigen/src/IterativeLinearSolvers/IterativeSolverBase.h
@@ -235,7 +235,7 @@ public:
     * matrix A, or modify a copy of A.
     */
   template<typename MatrixDerived>
-  Derived& compute(const EigenBase<MatrixDerived>& A)
+  EIGEN_NODISCARD Derived& compute(const EigenBase<MatrixDerived>& A)
   {
     grab(A.derived());
     m_preconditioner.compute(matrix());

--- a/Eigen/src/LU/FullPivLU.h
+++ b/Eigen/src/LU/FullPivLU.h
@@ -116,7 +116,7 @@ template<typename _MatrixType> class FullPivLU
       * \returns a reference to *this
       */
     template<typename InputType>
-    FullPivLU& compute(const EigenBase<InputType>& matrix) {
+    EIGEN_NODISCARD FullPivLU& compute(const EigenBase<InputType>& matrix) {
       m_lu = matrix.derived();
       computeInPlace();
       return *this;
@@ -239,7 +239,7 @@ template<typename _MatrixType> class FullPivLU
       */
     // FIXME this is a copy-paste of the base-class member to add the isInitialized assertion.
     template<typename Rhs>
-    inline const Solve<FullPivLU, Rhs>
+    EIGEN_NODISCARD inline const Solve<FullPivLU, Rhs>
     solve(const MatrixBase<Rhs>& b) const
     {
       eigen_assert(m_isInitialized && "LU is not initialized.");

--- a/Eigen/src/LU/PartialPivLU.h
+++ b/Eigen/src/LU/PartialPivLU.h
@@ -126,7 +126,7 @@ template<typename _MatrixType> class PartialPivLU
     explicit PartialPivLU(EigenBase<InputType>& matrix);
 
     template<typename InputType>
-    PartialPivLU& compute(const EigenBase<InputType>& matrix) {
+    EIGEN_NODISCARD PartialPivLU& compute(const EigenBase<InputType>& matrix) {
       m_lu = matrix.derived();
       compute();
       return *this;
@@ -171,7 +171,7 @@ template<typename _MatrixType> class PartialPivLU
       */
     // FIXME this is a copy-paste of the base-class member to add the isInitialized assertion.
     template<typename Rhs>
-    inline const Solve<PartialPivLU, Rhs>
+    EIGEN_NODISCARD inline const Solve<PartialPivLU, Rhs>
     solve(const MatrixBase<Rhs>& b) const
     {
       eigen_assert(m_isInitialized && "PartialPivLU is not initialized.");

--- a/Eigen/src/PardisoSupport/PardisoSupport.h
+++ b/Eigen/src/PardisoSupport/PardisoSupport.h
@@ -173,7 +173,7 @@ class PardisoImpl : public SparseSolverBase<Derived>
       */
     Derived& factorize(const MatrixType& matrix);
 
-    Derived& compute(const MatrixType& matrix);
+    EIGEN_NODISCARD Derived& compute(const MatrixType& matrix);
 
     template<typename Rhs,typename Dest>
     void _solve_impl(const MatrixBase<Rhs> &b, MatrixBase<Dest> &dest) const;

--- a/Eigen/src/QR/ColPivHouseholderQR.h
+++ b/Eigen/src/QR/ColPivHouseholderQR.h
@@ -171,7 +171,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
       * Output: \verbinclude ColPivHouseholderQR_solve.out
       */
     template<typename Rhs>
-    inline const Solve<ColPivHouseholderQR, Rhs>
+    EIGEN_NODISCARD inline const Solve<ColPivHouseholderQR, Rhs>
     solve(const MatrixBase<Rhs>& b) const
     {
       eigen_assert(m_isInitialized && "ColPivHouseholderQR is not initialized.");
@@ -208,7 +208,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
     }
 
     template<typename InputType>
-    ColPivHouseholderQR& compute(const EigenBase<InputType>& matrix);
+    EIGEN_NODISCARD ColPivHouseholderQR& compute(const EigenBase<InputType>& matrix);
 
     /** \returns a const reference to the column permutation matrix */
     const PermutationType& colsPermutation() const

--- a/Eigen/src/QR/CompleteOrthogonalDecomposition.h
+++ b/Eigen/src/QR/CompleteOrthogonalDecomposition.h
@@ -144,7 +144,7 @@ class CompleteOrthogonalDecomposition {
    *
    */
   template <typename Rhs>
-  inline const Solve<CompleteOrthogonalDecomposition, Rhs> solve(
+  EIGEN_NODISCARD inline const Solve<CompleteOrthogonalDecomposition, Rhs> solve(
       const MatrixBase<Rhs>& b) const {
     eigen_assert(m_cpqr.m_isInitialized &&
                  "CompleteOrthogonalDecomposition is not initialized.");
@@ -181,7 +181,7 @@ class CompleteOrthogonalDecomposition {
   const MatrixType& matrixT() const { return m_cpqr.matrixQR(); }
 
   template <typename InputType>
-  CompleteOrthogonalDecomposition& compute(const EigenBase<InputType>& matrix) {
+  EIGEN_NODISCARD CompleteOrthogonalDecomposition& compute(const EigenBase<InputType>& matrix) {
     // Compute the column pivoted QR factorization A P = Q R.
     m_cpqr.compute(matrix);
     computeInPlace();

--- a/Eigen/src/QR/FullPivHouseholderQR.h
+++ b/Eigen/src/QR/FullPivHouseholderQR.h
@@ -172,7 +172,7 @@ template<typename _MatrixType> class FullPivHouseholderQR
       * Output: \verbinclude FullPivHouseholderQR_solve.out
       */
     template<typename Rhs>
-    inline const Solve<FullPivHouseholderQR, Rhs>
+    EIGEN_NODISCARD inline const Solve<FullPivHouseholderQR, Rhs>
     solve(const MatrixBase<Rhs>& b) const
     {
       eigen_assert(m_isInitialized && "FullPivHouseholderQR is not initialized.");
@@ -192,7 +192,7 @@ template<typename _MatrixType> class FullPivHouseholderQR
     }
 
     template<typename InputType>
-    FullPivHouseholderQR& compute(const EigenBase<InputType>& matrix);
+    EIGEN_NODISCARD FullPivHouseholderQR& compute(const EigenBase<InputType>& matrix);
 
     /** \returns a const reference to the column permutation matrix */
     const PermutationType& colsPermutation() const

--- a/Eigen/src/QR/HouseholderQR.h
+++ b/Eigen/src/QR/HouseholderQR.h
@@ -136,7 +136,7 @@ template<typename _MatrixType> class HouseholderQR
       * Output: \verbinclude HouseholderQR_solve.out
       */
     template<typename Rhs>
-    inline const Solve<HouseholderQR, Rhs>
+    EIGEN_NODISCARD inline const Solve<HouseholderQR, Rhs>
     solve(const MatrixBase<Rhs>& b) const
     {
       eigen_assert(m_isInitialized && "HouseholderQR is not initialized.");
@@ -167,7 +167,7 @@ template<typename _MatrixType> class HouseholderQR
     }
 
     template<typename InputType>
-    HouseholderQR& compute(const EigenBase<InputType>& matrix) {
+    EIGEN_NODISCARD HouseholderQR& compute(const EigenBase<InputType>& matrix) {
       m_qr = matrix.derived();
       computeInPlace();
       return *this;

--- a/Eigen/src/SVD/BDCSVD.h
+++ b/Eigen/src/SVD/BDCSVD.h
@@ -156,7 +156,7 @@ public:
    * Thin unitaries are only available if your matrix type has a Dynamic number of columns (for example MatrixXf). They also are not
    * available with the (non - default) FullPivHouseholderQR preconditioner.
    */
-  BDCSVD& compute(const MatrixType& matrix, unsigned int computationOptions);
+  EIGEN_NODISCARD BDCSVD& compute(const MatrixType& matrix, unsigned int computationOptions);
 
   /** \brief Method performing the decomposition of given matrix using current options.
    *
@@ -164,7 +164,7 @@ public:
    *
    * This method uses the current \a computationOptions, as already passed to the constructor or to compute(const MatrixType&, unsigned int).
    */
-  BDCSVD& compute(const MatrixType& matrix)
+  EIGEN_NODISCARD BDCSVD& compute(const MatrixType& matrix)
   {
     return compute(matrix, this->m_computationOptions);
   }

--- a/Eigen/src/SVD/JacobiSVD.h
+++ b/Eigen/src/SVD/JacobiSVD.h
@@ -558,7 +558,7 @@ template<typename _MatrixType, int QRPreconditioner> class JacobiSVD
      * Thin unitaries are only available if your matrix type has a Dynamic number of columns (for example MatrixXf). They also are not
      * available with the (non-default) FullPivHouseholderQR preconditioner.
      */
-    JacobiSVD& compute(const MatrixType& matrix, unsigned int computationOptions);
+    EIGEN_NODISCARD JacobiSVD& compute(const MatrixType& matrix, unsigned int computationOptions);
 
     /** \brief Method performing the decomposition of given matrix using current options.
      *
@@ -566,7 +566,7 @@ template<typename _MatrixType, int QRPreconditioner> class JacobiSVD
      *
      * This method uses the current \a computationOptions, as already passed to the constructor or to compute(const MatrixType&, unsigned int).
      */
-    JacobiSVD& compute(const MatrixType& matrix)
+    EIGEN_NODISCARD JacobiSVD& compute(const MatrixType& matrix)
     {
       return compute(matrix, m_computationOptions);
     }

--- a/Eigen/src/SVD/SVDBase.h
+++ b/Eigen/src/SVD/SVDBase.h
@@ -202,7 +202,7 @@ public:
     * In other words, the returned solution is guaranteed to minimize the Euclidean norm \f$ \Vert A x - b \Vert \f$.
     */
   template<typename Rhs>
-  inline const Solve<Derived, Rhs>
+  EIGEN_NODISCARD inline const Solve<Derived, Rhs>
   solve(const MatrixBase<Rhs>& b) const
   {
     eigen_assert(m_isInitialized && "SVD is not initialized.");

--- a/Eigen/src/SVD/UpperBidiagonalization.h
+++ b/Eigen/src/SVD/UpperBidiagonalization.h
@@ -61,8 +61,8 @@ template<typename _MatrixType> class UpperBidiagonalization
       compute(matrix);
     }
     
-    UpperBidiagonalization& compute(const MatrixType& matrix);
-    UpperBidiagonalization& computeUnblocked(const MatrixType& matrix);
+    EIGEN_NODISCARD UpperBidiagonalization& compute(const MatrixType& matrix);
+    EIGEN_NODISCARD UpperBidiagonalization& computeUnblocked(const MatrixType& matrix);
     
     const MatrixType& householder() const { return m_householder; }
     const BidiagonalType& bidiagonal() const { return m_bidiagonal; }

--- a/Eigen/src/SparseCholesky/SimplicialCholesky.h
+++ b/Eigen/src/SparseCholesky/SimplicialCholesky.h
@@ -361,7 +361,7 @@ public:
     }
     
     /** Computes the sparse Cholesky decomposition of \a matrix */
-    SimplicialLLT& compute(const MatrixType& matrix)
+    EIGEN_NODISCARD SimplicialLLT& compute(const MatrixType& matrix)
     {
       Base::template compute<false>(matrix);
       return *this;
@@ -458,7 +458,7 @@ public:
     }
 
     /** Computes the sparse Cholesky decomposition of \a matrix */
-    SimplicialLDLT& compute(const MatrixType& matrix)
+    EIGEN_NODISCARD SimplicialLDLT& compute(const MatrixType& matrix)
     {
       Base::template compute<true>(matrix);
       return *this;
@@ -550,7 +550,7 @@ public:
     }
     
     /** Computes the sparse Cholesky decomposition of \a matrix */
-    SimplicialCholesky& compute(const MatrixType& matrix)
+    EIGEN_NODISCARD SimplicialCholesky& compute(const MatrixType& matrix)
     {
       if(m_LDLT)
         Base::template compute<true>(matrix);

--- a/Eigen/src/SparseCore/SparseSolverBase.h
+++ b/Eigen/src/SparseCore/SparseSolverBase.h
@@ -80,11 +80,11 @@ class SparseSolverBase : internal::noncopyable
     const Derived& derived() const { return *static_cast<const Derived*>(this); }
     
     /** \returns an expression of the solution x of \f$ A x = b \f$ using the current decomposition of A.
-      *
+      * \warning Discarding the returned expression has no effect.
       * \sa compute()
       */
     template<typename Rhs>
-    inline const Solve<Derived, Rhs>
+    EIGEN_NODISCARD inline const Solve<Derived, Rhs>
     solve(const MatrixBase<Rhs>& b) const
     {
       eigen_assert(m_isInitialized && "Solver is not initialized.");
@@ -93,11 +93,11 @@ class SparseSolverBase : internal::noncopyable
     }
     
     /** \returns an expression of the solution x of \f$ A x = b \f$ using the current decomposition of A.
-      *
+      * \warning Discarding the returned expression has no effect.
       * \sa compute()
       */
     template<typename Rhs>
-    inline const Solve<Derived, Rhs>
+    EIGEN_NODISCARD inline const Solve<Derived, Rhs>
     solve(const SparseMatrixBase<Rhs>& b) const
     {
       eigen_assert(m_isInitialized && "Solver is not initialized.");

--- a/Eigen/src/SparseLU/SparseLU.h
+++ b/Eigen/src/SparseLU/SparseLU.h
@@ -188,7 +188,7 @@ class SparseLU : public SparseSolverBase<SparseLU<_MatrixType,_OrderingType> >, 
       * \sa compute()
       */
     template<typename Rhs>
-    inline const Solve<SparseLU, Rhs> solve(const MatrixBase<Rhs>& B) const;
+    EIGEN_NODISCARD inline const Solve<SparseLU, Rhs> solve(const MatrixBase<Rhs>& B) const;
 #endif // EIGEN_PARSED_BY_DOXYGEN
     
     /** \brief Reports whether previous computation was successful.

--- a/Eigen/src/SparseQR/SparseQR.h
+++ b/Eigen/src/SparseQR/SparseQR.h
@@ -230,14 +230,14 @@ class SparseQR : public SparseSolverBase<SparseQR<_MatrixType,_OrderingType> >
       * \sa compute()
       */
     template<typename Rhs>
-    inline const Solve<SparseQR, Rhs> solve(const MatrixBase<Rhs>& B) const 
+    EIGEN_NODISCARD inline const Solve<SparseQR, Rhs> solve(const MatrixBase<Rhs>& B) const
     {
       eigen_assert(m_isInitialized && "The factorization should be called first, use compute()");
       eigen_assert(this->rows() == B.rows() && "SparseQR::solve() : invalid number of rows in the right hand side matrix");
       return Solve<SparseQR, Rhs>(*this, B.derived());
     }
     template<typename Rhs>
-    inline const Solve<SparseQR, Rhs> solve(const SparseMatrixBase<Rhs>& B) const
+    EIGEN_NODISCARD inline const Solve<SparseQR, Rhs> solve(const SparseMatrixBase<Rhs>& B) const
     {
           eigen_assert(m_isInitialized && "The factorization should be called first, use compute()");
           eigen_assert(this->rows() == B.rows() && "SparseQR::solve() : invalid number of rows in the right hand side matrix");


### PR DESCRIPTION
## Summary
- warn when discarding `solve()` return values
- mark numerous solver methods and compute functions as `[[nodiscard]]`

## Testing
- `ctest --output-on-failure -j1` *(fails: No tests were found)*