### PR TITLE
Add clang-tidy helper and config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,12 @@ repos:
     hooks:
       - id: clang-tidy
         additional_dependencies: [clang-tidy==17.0.6]
+        args: [-p, build]
         files: "\\.(c|cc|cpp|cxx|h|hpp)$"
       - id: clang-tidy
         name: clang-tidy-c23
         additional_dependencies: [clang-tidy==17.0.6]
-        args: [--config-file=.clang-tidy-c23]
+        args: [--config-file=.clang-tidy-c23, -p, build]
         files: "\\.(c|h)$"
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ project(Eigen3)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 cmake_minimum_required(VERSION 2.8.5)
 
 # guard against in-source builds

--- a/README.md
+++ b/README.md
@@ -85,4 +85,20 @@ Clang-Tidy configurations for both C23 and C++23 live in `.clang-tidy-c23` and
 `.clang-tidy`.  The project builds with either GCC or Clang; the test scripts
 use whichever compiler is available.
 
+### Running clang-tidy
+
+Generate a build directory with a compile database:
+
+```bash
+mkdir build && cd build
+cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+```
+
+Then execute the helper script which runs clang-tidy across the tree:
+
+```bash
+../scripts/run-clang-tidy.sh
+```
+
+
 

--- a/scripts/run-clang-tidy.sh
+++ b/scripts/run-clang-tidy.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUILD_DIR=${1:-build}
+if [ ! -f "${BUILD_DIR}/compile_commands.json" ]; then
+  echo "compile_commands.json not found in ${BUILD_DIR}" >&2
+  echo "Generate it with: cmake -B ${BUILD_DIR} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .." >&2
+  exit 1
+fi
+
+FILES=$(git ls-files '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hpp')
+for f in $FILES; do
+  clang-tidy -p "${BUILD_DIR}" "$f"
+done


### PR DESCRIPTION
## Summary
- export compile commands from CMake for clang-tidy
- run clang-tidy via pre-commit with a build directory
- provide helper script to run clang-tidy manually
- document clang-tidy usage in README

## Testing
- `bash tests/run_all.sh` *(fails: gcc: error: unrecognized command-line option ‘-std=c23’)*