### PR TITLE
Setup local pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,28 @@
 repos:
-  - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v17.0.6
+  - repo: local
     hooks:
       - id: clang-format
-        additional_dependencies: [clang-format==17.0.6]
-  - repo: https://github.com/pre-commit/mirrors-clang-tidy
-    rev: v17.0.6
-    hooks:
-      - id: clang-tidy
-        additional_dependencies: [clang-tidy==17.0.6]
+        name: clang-format
+        entry: hooks/clang-format.sh
+        language: script
         files: "\\.(c|cc|cpp|cxx|h|hpp)$"
       - id: clang-tidy
+        name: clang-tidy
+        entry: hooks/clang-tidy.sh
+        language: script
+        files: "\\.(c|cc|cpp|cxx|h|hpp)$"
+      - id: clang-tidy-c23
         name: clang-tidy-c23
-        additional_dependencies: [clang-tidy==17.0.6]
-        args: [--config-file=.clang-tidy-c23]
+        entry: hooks/clang-tidy-c23.sh
+        language: script
         files: "\\.(c|h)$"
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
-    hooks:
       - id: end-of-file-fixer
+        name: end-of-file-fixer
+        entry: hooks/end-of-file-fixer.py
+        language: python
+        files: ''
       - id: trailing-whitespace
+        name: trailing-whitespace
+        entry: hooks/trailing-whitespace.py
+        language: python
+        files: ''

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ entire suite including the Go tests.
 ## Development Environment
 
 Run `./setup.sh` to install the toolchain including GCC, Clang/LLVM, Meson and
-pre-commit.  After installation you can enable the git hooks with:
+pre-commit.  The pre-commit hooks are configured to use local scripts so they
+work even when the network is unavailable. After installation you can enable
+the git hooks with:
 
 ```bash
 pre-commit install

--- a/hooks/clang-format.sh
+++ b/hooks/clang-format.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+clang-format -i "$@"

--- a/hooks/clang-tidy-c23.sh
+++ b/hooks/clang-tidy-c23.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+clang-tidy --config-file=.clang-tidy-c23 "$@"

--- a/hooks/clang-tidy.sh
+++ b/hooks/clang-tidy.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+clang-tidy "$@"

--- a/hooks/end-of-file-fixer.py
+++ b/hooks/end-of-file-fixer.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+import sys, pathlib
+
+for path_str in sys.argv[1:]:
+    p = pathlib.Path(path_str)
+    if not p.exists():
+        continue
+    data = p.read_bytes()
+    if not data.endswith(b"\n"):
+        p.write_bytes(data + b"\n")

--- a/hooks/trailing-whitespace.py
+++ b/hooks/trailing-whitespace.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import sys, pathlib, re
+
+for path_str in sys.argv[1:]:
+    p = pathlib.Path(path_str)
+    if not p.exists():
+        continue
+    text = p.read_text()
+    lines = [re.sub(r'[ \t]+$', '', line) for line in text.splitlines()]
+    if text.endswith('\n'):
+        new_text = '\n'.join(lines) + '\n'
+    else:
+        new_text = '\n'.join(lines)
+    p.write_text(new_text)

--- a/setup.sh
+++ b/setup.sh
@@ -197,6 +197,11 @@ command -v clang-format >/dev/null 2>&1 || ln -s "$(command -v clang-format-17)"
 pre-commit --version >/dev/null 2>&1 || echo "pre-commit --version failed" >> "$FAIL_LOG"
 pytest --version >/dev/null 2>&1 || echo "pytest --version failed" >> "$FAIL_LOG"
 
+# Ensure local hook scripts are executable
+if [ -d hooks ]; then
+  chmod +x hooks/* || true
+fi
+
 apt-get clean || echo "apt-get clean failed" >> "$FAIL_LOG"
 rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- make clang-format/clang-tidy hooks local scripts
- add simple whitespace fixer scripts
- ensure hook scripts are executable in setup.sh
- note offline pre-commit usage in README

## Testing
- `tests/run_all.sh` *(fails: compilation errors)*