### PR TITLE
Improve scan_templates error reporting

### DIFF
--- a/porter/README.md
+++ b/porter/README.md
@@ -18,3 +18,12 @@ validate everything:
 ```bash
 bash porter/build_all.sh
 ```
+
+## Troubleshooting AST Generation
+
+`scan_templates.py` uses clang's Python bindings to generate AST dumps. If you
+see warnings about failed parsing or missing translation units, ensure that
+libclang is installed and visible. On Debian-based systems install the
+`libclang-dev` package. If `libclang.so` lives in a non-standard location,
+export the environment variable `LIBCLANG_PATH` pointing to the shared library
+before running the script.

--- a/porter/scan_templates.py
+++ b/porter/scan_templates.py
@@ -12,6 +12,7 @@ families which can be filled in later.
 import os
 import sys
 import re
+import warnings
 
 try:
     import yaml
@@ -139,8 +140,14 @@ def main():
             if HAVE_CLANG:
                 try:
                     tu = index.parse(path, args=compile_args)
+                    if tu is None or tu.cursor is None:
+                        raise RuntimeError("libclang returned no translation unit")
                 except Exception as exc:
-                    print(f"Failed to parse {path}: {exc}", file=sys.stderr)
+                    warnings.warn(
+                        f"Failed to parse {rel_path} with clang: {exc}. "
+                        "Set LIBCLANG_PATH to the directory containing libclang.so "
+                        "or install the Clang package to enable AST generation."
+                    )
                     tu = None
             else:
                 tu = None


### PR DESCRIPTION
## Summary
- warn about failed clang parses in `scan_templates.py`
- mention `LIBCLANG_PATH` and `libclang-dev` troubleshooting in porter README

## Testing
- `python3 -m py_compile porter/scan_templates.py`
- `bash tests/run_all.sh` *(fails: `gcc: error: unrecognized command-line option ‘-std=c23’`)*