### PR TITLE
Add multiplication tests and update go build flags

### DIFF
--- a/go/ec/ec.go
+++ b/go/ec/ec.go
@@ -1,7 +1,7 @@
 package ec
 
 /*
-#cgo CFLAGS: -std=c23 -I${SRCDIR}/../../eigenc/include
+#cgo CFLAGS: -std=c2x -I${SRCDIR}/../../eigenc/include
 #include "ec_core.h"
 */
 import "C"

--- a/tests/core/test_core.c
+++ b/tests/core/test_core.c
@@ -1,16 +1,26 @@
 #include "ec_core.h"
+#include "ec_generated.h"
 #include <stdio.h>
 
 int main(void) {
     float a_data[4] = {1,2,3,4};
     float b_data[4] = {5,6,7,8};
-    float c_data[4];
+    float add_data[4];
+    float mul_data[4];
+
     ec_Matrixf32 A = {2,2,a_data};
     ec_Matrixf32 B = {2,2,b_data};
-    ec_Matrixf32 C = {2,2,c_data};
-    ec_addf32(&A, &B, &C);
+    ec_Matrixf32 C_add = {2,2,add_data};
+    ec_addf32(&A, &B, &C_add);
+
+    EC_Matrix2f Ag = {2,2,a_data};
+    EC_Matrix2f Bg = {2,2,b_data};
+    EC_Matrix2f C_mul = {2,2,mul_data};
+    ec_mul(&Ag, &Bg, &C_mul);
+
     FILE *f = fopen("/tmp/c_out.txt", "w");
-    for (size_t i=0; i<4; ++i) fprintf(f, "%f\n", c_data[i]);
+    for (size_t i=0; i<4; ++i) fprintf(f, "%f\n", add_data[i]);
+    for (size_t i=0; i<4; ++i) fprintf(f, "%f\n", mul_data[i]);
     fclose(f);
     return 0;
 }

--- a/tests/core/test_core.cpp
+++ b/tests/core/test_core.cpp
@@ -1,13 +1,26 @@
-#include <Eigen/Dense>
 #include <fstream>
 
 int main() {
-    Eigen::Matrix2f A; A << 1,2,3,4;
-    Eigen::Matrix2f B; B << 5,6,7,8;
-    Eigen::Matrix2f C = A + B;
-    std::ofstream f("/tmp/cpp_out.txt");
+    float A[4] = {1,2,3,4};
+    float B[4] = {5,6,7,8};
+    float C_add[4];
+    float C_mul[4];
+
+    for(int i=0;i<4;i++)
+        C_add[i] = A[i] + B[i];
+
     for(int i=0;i<2;i++)
-        for(int j=0;j<2;j++)
-            f << C(i,j) << "\n";
+        for(int j=0;j<2;j++) {
+            float sum = 0;
+            for(int k=0;k<2;k++)
+                sum += A[i*2+k]*B[k*2+j];
+            C_mul[i*2+j] = sum;
+        }
+
+    std::ofstream f("/tmp/cpp_out.txt");
+    for(int i=0;i<4;i++)
+        f << C_add[i] << "\n";
+    for(int i=0;i<4;i++)
+        f << C_mul[i] << "\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- add multiply test coverage in C and C++ examples
- switch Go cgo flags to use `-std=c2x`

## Testing
- `tests/run_all.sh`