### PR TITLE
Extend EC tests for matrix multiplication

### DIFF
--- a/tests/core/test_core.c
+++ b/tests/core/test_core.c
@@ -16,7 +16,7 @@ int main(void) {
     EC_Matrix2f Ag = {2,2,a_data};
     EC_Matrix2f Bg = {2,2,b_data};
     EC_Matrix2f C_mul = {2,2,mul_data};
-    ec_mul(&Ag, &Bg, &C_mul);
+    EC_Matrix2f_mul(&Ag, &Bg, &C_mul);
 
     FILE *f = fopen("/tmp/c_out.txt", "w");
     for (size_t i=0; i<4; ++i) fprintf(f, "%f\n", add_data[i]);

--- a/tests/core/test_core.cpp
+++ b/tests/core/test_core.cpp
@@ -1,4 +1,5 @@
 #include <fstream>
+#include "ec_generated.h"
 
 int main() {
     float A[4] = {1,2,3,4};
@@ -9,13 +10,10 @@ int main() {
     for(int i=0;i<4;i++)
         C_add[i] = A[i] + B[i];
 
-    for(int i=0;i<2;i++)
-        for(int j=0;j<2;j++) {
-            float sum = 0;
-            for(int k=0;k<2;k++)
-                sum += A[i*2+k]*B[k*2+j];
-            C_mul[i*2+j] = sum;
-        }
+    EC_Matrix2f Ac = {2,2,A};
+    EC_Matrix2f Bc = {2,2,B};
+    EC_Matrix2f Cc = {2,2,C_mul};
+    EC_Matrix2f_mul(&Ac, &Bc, &Cc);
 
     std::ofstream f("/tmp/cpp_out.txt");
     for(int i=0;i<4;i++)

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -7,7 +7,7 @@ ROOT_DIR="$(cd "$(dirname "$0")/.."; pwd)"
 gcc -std=c23 -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.c" -o /tmp/ec_test \
   || gcc -std=c2x -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.c" -o /tmp/ec_test
 
-g++ -std=c++23 -I"${ROOT_DIR}" "${ROOT_DIR}/tests/core/test_core.cpp" -o /tmp/eigen_test23
+g++ -std=c++23 -I"${ROOT_DIR}" -I"${ROOT_DIR}/eigenc/include" "${ROOT_DIR}/tests/core/test_core.cpp" -o /tmp/eigen_test23
 
 /tmp/ec_test
 /tmp/eigen_test23


### PR DESCRIPTION
## Summary
- update C and C++ core tests to use `EC_Matrix2f_mul`
- compile C++ test with generated headers
- adjust `run_all.sh` to pass EigenC include path

## Testing
- `bash tests/run_all.sh`