### PR TITLE
Improve storage by using [[no_unique_address]]

### DIFF
--- a/Eigen/src/Core/CwiseBinaryOp.h
+++ b/Eigen/src/Core/CwiseBinaryOp.h
@@ -138,9 +138,9 @@ class CwiseBinaryOp :
     const BinaryOp& functor() const { return m_functor; }
 
   protected:
-    LhsNested m_lhs;
-    RhsNested m_rhs;
-    const BinaryOp m_functor;
+    [[no_unique_address]] LhsNested m_lhs;
+    [[no_unique_address]] RhsNested m_rhs;
+    [[no_unique_address]] const BinaryOp m_functor;
 };
 
 // Generic API dispatcher

--- a/Eigen/src/Core/CwiseNullaryOp.h
+++ b/Eigen/src/Core/CwiseNullaryOp.h
@@ -84,9 +84,9 @@ class CwiseNullaryOp : public internal::dense_xpr_base< CwiseNullaryOp<NullaryOp
     const NullaryOp& functor() const { return m_functor; }
 
   protected:
-    const internal::variable_if_dynamic<Index, RowsAtCompileTime> m_rows;
-    const internal::variable_if_dynamic<Index, ColsAtCompileTime> m_cols;
-    const NullaryOp m_functor;
+    [[no_unique_address]] const internal::variable_if_dynamic<Index, RowsAtCompileTime> m_rows;
+    [[no_unique_address]] const internal::variable_if_dynamic<Index, ColsAtCompileTime> m_cols;
+    [[no_unique_address]] const NullaryOp m_functor;
 };
 
 

--- a/Eigen/src/Core/CwiseTernaryOp.h
+++ b/Eigen/src/Core/CwiseTernaryOp.h
@@ -175,10 +175,10 @@ class CwiseTernaryOp : public CwiseTernaryOpImpl<
   const TernaryOp& functor() const { return m_functor; }
 
  protected:
-  Arg1Nested m_arg1;
-  Arg2Nested m_arg2;
-  Arg3Nested m_arg3;
-  const TernaryOp m_functor;
+  [[no_unique_address]] Arg1Nested m_arg1;
+  [[no_unique_address]] Arg2Nested m_arg2;
+  [[no_unique_address]] Arg3Nested m_arg3;
+  [[no_unique_address]] const TernaryOp m_functor;
 };
 
 // Generic API dispatcher

--- a/Eigen/src/Core/CwiseUnaryOp.h
+++ b/Eigen/src/Core/CwiseUnaryOp.h
@@ -85,8 +85,8 @@ class CwiseUnaryOp : public CwiseUnaryOpImpl<UnaryOp, XprType, typename internal
     nestedExpression() { return m_xpr; }
 
   protected:
-    XprTypeNested m_xpr;
-    const UnaryOp m_functor;
+    [[no_unique_address]] XprTypeNested m_xpr;
+    [[no_unique_address]] const UnaryOp m_functor;
 };
 
 // Generic API dispatcher

--- a/Eigen/src/Core/CwiseUnaryView.h
+++ b/Eigen/src/Core/CwiseUnaryView.h
@@ -84,8 +84,8 @@ class CwiseUnaryView : public CwiseUnaryViewImpl<ViewOp, MatrixType, typename in
     nestedExpression() { return m_matrix.const_cast_derived(); }
 
   protected:
-    MatrixTypeNested m_matrix;
-    ViewOp m_functor;
+    [[no_unique_address]] MatrixTypeNested m_matrix;
+    [[no_unique_address]] ViewOp m_functor;
 };
 
 // Generic API dispatcher

--- a/Eigen/src/Core/VectorwiseOp.h
+++ b/Eigen/src/Core/VectorwiseOp.h
@@ -77,8 +77,8 @@ class PartialReduxExpr : public internal::dense_xpr_base< PartialReduxExpr<Matri
     const MemberOp& functor() const { return m_functor; }
 
   protected:
-    typename MatrixType::Nested m_matrix;
-    const MemberOp m_functor;
+    [[no_unique_address]] typename MatrixType::Nested m_matrix;
+    [[no_unique_address]] const MemberOp m_functor;
 };
 
 #define EIGEN_MEMBER_FUNCTOR(MEMBER,COST)                               \


### PR DESCRIPTION
## Summary
- apply `[[no_unique_address]]` attribute to nested expression and functor members
  in several expression template classes

## Testing
- `git diff --cached --stat`