### PR TITLE
Modernize type traits

### DIFF
--- a/Eigen/src/Core/Array.h
+++ b/Eigen/src/Core/Array.h
@@ -9,6 +9,7 @@
 
 #ifndef EIGEN_ARRAY_H
 #define EIGEN_ARRAY_H
+#include <type_traits>
 
 namespace Eigen {
 
@@ -239,7 +240,7 @@ class Array
     template<typename OtherDerived>
     EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Array(const EigenBase<OtherDerived> &other,
-                              std::enable_if_t<internal::is_convertible<typename OtherDerived::Scalar,Scalar>::value,
+                              std::enable_if_t<std::is_convertible_v<typename OtherDerived::Scalar,Scalar>,
                                               PrivateType> = PrivateType())
       : Base(other.derived())
     { }

--- a/Eigen/src/Core/CoreEvaluators.h
+++ b/Eigen/src/Core/CoreEvaluators.h
@@ -1377,7 +1377,7 @@ struct evaluator<PartialReduxExpr<ArgType, MemberOp, Direction> >
   }
 
 protected:
-  typename internal::add_const_on_value_type<ArgTypeNested>::type m_arg;
+  std::add_const_t<ArgTypeNested> m_arg;
   const MemberOp m_functor;
 };
 

--- a/Eigen/src/Core/DenseBase.h
+++ b/Eigen/src/Core/DenseBase.h
@@ -389,7 +389,7 @@ template<typename Derived> class DenseBase
     EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
     Derived& operator/=(const Scalar& other);
 
-    typedef typename internal::add_const_on_value_type<typename internal::eval<Derived>::type>::type EvalReturnType;
+    typedef std::add_const_t<typename internal::eval<Derived>::type> EvalReturnType;
     /** \returns the matrix or vector obtained by evaluating this expression.
       *
       * Notice that in the case of a plain matrix or vector (not an expression) this function just returns

--- a/Eigen/src/Core/DenseCoeffsBase.h
+++ b/Eigen/src/Core/DenseCoeffsBase.h
@@ -9,13 +9,14 @@
 
 #ifndef EIGEN_DENSECOEFFSBASE_H
 #define EIGEN_DENSECOEFFSBASE_H
+#include <type_traits>
 
 namespace Eigen {
 
 namespace internal {
-template<typename T> struct add_const_on_value_type_if_arithmetic
-{
-  typedef typename conditional<is_arithmetic<T>::value, T, typename add_const_on_value_type<T>::type>::type type;
+template <typename T>
+struct add_const_on_value_type_if_arithmetic {
+  using type = std::conditional_t<std::is_arithmetic_v<T>, T, std::add_const_t<T>>;
 };
 }
 
@@ -47,7 +48,7 @@ class DenseCoeffsBase<Derived,ReadOnlyAccessors> : public EigenBase<Derived>
     // not possible, since the underlying expressions might not offer a valid address the reference could be referring to.
     typedef typename internal::conditional<bool(internal::traits<Derived>::Flags&LvalueBit),
                          const Scalar&,
-                         typename internal::conditional<internal::is_arithmetic<Scalar>::value, Scalar, const Scalar>::type
+                         typename internal::conditional<std::is_arithmetic_v<Scalar>, Scalar, const Scalar>::type
                      >::type CoeffReturnType;
 
     typedef typename internal::add_const_on_value_type_if_arithmetic<

--- a/Eigen/src/Core/ForceAlignedAccess.h
+++ b/Eigen/src/Core/ForceAlignedAccess.h
@@ -9,6 +9,7 @@
 
 #ifndef EIGEN_FORCEALIGNEDACCESS_H
 #define EIGEN_FORCEALIGNEDACCESS_H
+#include <type_traits>
 
 namespace Eigen {
 
@@ -124,7 +125,7 @@ MatrixBase<Derived>::forceAlignedAccess()
   */
 template<typename Derived>
 template<bool Enable>
-inline typename internal::add_const_on_value_type<typename internal::conditional<Enable,ForceAlignedAccess<Derived>,Derived&>::type>::type
+inline std::add_const_t<typename internal::conditional<Enable,ForceAlignedAccess<Derived>,Derived&>::type>
 MatrixBase<Derived>::forceAlignedAccessIf() const
 {
   return derived();  // FIXME This should not work but apparently is never used

--- a/Eigen/src/Core/MathFunctions.h
+++ b/Eigen/src/Core/MathFunctions.h
@@ -9,6 +9,7 @@
 
 #ifndef EIGEN_MATHFUNCTIONS_H
 #define EIGEN_MATHFUNCTIONS_H
+#include <type_traits>
 
 // source: http://www.geom.uiuc.edu/~huberty/math5337/groupe/digits.html
 // TODO this should better be moved to NumTraits
@@ -760,22 +761,22 @@ inline EIGEN_MATHFUNC_RETVAL(random, Scalar) random()
 
 template<typename T>
 EIGEN_DEVICE_FUNC
-std::enable_if_t<internal::is_integral<T>::value,bool>
+std::enable_if_t<std::is_integral_v<T>,bool>
 isnan_impl(const T&) { return false; }
 
 template<typename T>
 EIGEN_DEVICE_FUNC
-std::enable_if_t<internal::is_integral<T>::value,bool>
+std::enable_if_t<std::is_integral_v<T>,bool>
 isinf_impl(const T&) { return false; }
 
 template<typename T>
 EIGEN_DEVICE_FUNC
-std::enable_if_t<internal::is_integral<T>::value,bool>
+std::enable_if_t<std::is_integral_v<T>,bool>
 isfinite_impl(const T&) { return true; }
 
 template<typename T>
 EIGEN_DEVICE_FUNC
-std::enable_if_t<(!internal::is_integral<T>::value)&&(!NumTraits<T>::IsComplex),bool>
+std::enable_if_t<(!std::is_integral_v<T>)&&(!NumTraits<T>::IsComplex),bool>
 isfinite_impl(const T& x)
 {
   #ifdef EIGEN_CUDA_ARCH
@@ -790,7 +791,7 @@ isfinite_impl(const T& x)
 
 template<typename T>
 EIGEN_DEVICE_FUNC
-std::enable_if_t<(!internal::is_integral<T>::value)&&(!NumTraits<T>::IsComplex),bool>
+std::enable_if_t<(!std::is_integral_v<T>)&&(!NumTraits<T>::IsComplex),bool>
 isinf_impl(const T& x)
 {
   #ifdef EIGEN_CUDA_ARCH
@@ -805,7 +806,7 @@ isinf_impl(const T& x)
 
 template<typename T>
 EIGEN_DEVICE_FUNC
-std::enable_if_t<(!internal::is_integral<T>::value)&&(!NumTraits<T>::IsComplex),bool>
+std::enable_if_t<(!std::is_integral_v<T>)&&(!NumTraits<T>::IsComplex),bool>
 isnan_impl(const T& x)
 {
   #ifdef EIGEN_CUDA_ARCH
@@ -1005,7 +1006,7 @@ inline EIGEN_MATHFUNC_RETVAL(real, Scalar) real(const Scalar& x)
 
 template<typename Scalar>
 EIGEN_DEVICE_FUNC
-inline typename internal::add_const_on_value_type< EIGEN_MATHFUNC_RETVAL(real_ref, Scalar) >::type real_ref(const Scalar& x)
+inline std::add_const_t<EIGEN_MATHFUNC_RETVAL(real_ref, Scalar)> real_ref(const Scalar& x)
 {
   return internal::real_ref_impl<Scalar>::run(x);
 }
@@ -1033,7 +1034,7 @@ inline EIGEN_MATHFUNC_RETVAL(arg, Scalar) arg(const Scalar& x)
 
 template<typename Scalar>
 EIGEN_DEVICE_FUNC
-inline typename internal::add_const_on_value_type< EIGEN_MATHFUNC_RETVAL(imag_ref, Scalar) >::type imag_ref(const Scalar& x)
+inline std::add_const_t<EIGEN_MATHFUNC_RETVAL(imag_ref, Scalar)> imag_ref(const Scalar& x)
 {
   return internal::imag_ref_impl<Scalar>::run(x);
 }

--- a/Eigen/src/Core/NumTraits.h
+++ b/Eigen/src/Core/NumTraits.h
@@ -119,7 +119,7 @@ template<typename T> struct GenericNumTraits
     IsInteger = std::numeric_limits<T>::is_integer,
     IsSigned = std::numeric_limits<T>::is_signed,
     IsComplex = 0,
-    RequireInitialization = internal::is_arithmetic<T>::value ? 0 : 1,
+    RequireInitialization = std::is_arithmetic_v<T> ? 0 : 1,
     ReadCost = 1,
     AddCost = 1,
     MulCost = 1

--- a/Eigen/src/Core/PlainObjectBase.h
+++ b/Eigen/src/Core/PlainObjectBase.h
@@ -10,6 +10,7 @@
 
 #ifndef EIGEN_DENSESTORAGEBASE_H
 #define EIGEN_DENSESTORAGEBASE_H
+#include <type_traits>
 
 #if defined(EIGEN_INITIALIZE_MATRICES_BY_ZERO)
 # define EIGEN_INITIALIZE_COEFFS
@@ -769,7 +770,7 @@ class PlainObjectBase : public internal::dense_xpr_base<Derived>::type
     // then the argument is meant to be the size of the object.
     template<typename T>
     EIGEN_DEVICE_FUNC
-    EIGEN_STRONG_INLINE void _init1(Index size, std::enable_if_t<(Base::SizeAtCompileTime!=1 || !internal::is_convertible<T, Scalar>::value)
+    EIGEN_STRONG_INLINE void _init1(Index size, std::enable_if_t<(Base::SizeAtCompileTime!=1 || !std::is_convertible_v<T, Scalar>)
                                                                               && ((!internal::is_same<typename internal::traits<Derived>::XprKind,ArrayXpr>::value || Base::SizeAtCompileTime==Dynamic)),T>::type* = 0)
     {
       // NOTE MSVC 2008 complains if we directly put bool(NumTraits<T>::IsInteger) as the EIGEN_STATIC_ASSERT argument.
@@ -783,7 +784,7 @@ class PlainObjectBase : public internal::dense_xpr_base<Derived>::type
     // We have a 1x1 matrix/array => the argument is interpreted as the value of the unique coefficient (case where scalar type can be implicitely converted)
     template<typename T>
     EIGEN_DEVICE_FUNC
-    EIGEN_STRONG_INLINE void _init1(const Scalar& val0, std::enable_if_t<Base::SizeAtCompileTime==1 && internal::is_convertible<T, Scalar>::value,T>::type* = 0)
+    EIGEN_STRONG_INLINE void _init1(const Scalar& val0, std::enable_if_t<Base::SizeAtCompileTime==1 && std::is_convertible_v<T, Scalar>,T>::type* = 0)
     {
       EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(PlainObjectBase, 1)
       m_storage.data()[0] = val0;
@@ -796,7 +797,7 @@ class PlainObjectBase : public internal::dense_xpr_base<Derived>::type
                                     std::enable_if_t<(!internal::is_same<Index,Scalar>::value)
                                                                   && (internal::is_same<Index,T>::value)
                                                                   && Base::SizeAtCompileTime==1
-                                                                  && internal::is_convertible<T, Scalar>::value,T*>::type* = 0)
+                                                                  && std::is_convertible_v<T, Scalar>,T*>::type* = 0)
     {
       EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(PlainObjectBase, 1)
       m_storage.data()[0] = Scalar(val0);
@@ -851,7 +852,7 @@ class PlainObjectBase : public internal::dense_xpr_base<Derived>::type
     EIGEN_STRONG_INLINE void _init1(const Scalar& val0,
                                     std::enable_if_t<Base::SizeAtCompileTime!=Dynamic
                                                                   && Base::SizeAtCompileTime!=1
-                                                                  && internal::is_convertible<T, Scalar>::value
+                                                                  && std::is_convertible_v<T, Scalar>
                                                                   && internal::is_same<typename internal::traits<Derived>::XprKind,ArrayXpr>::value,T>::type* = 0)
     {
       Base::setConstant(val0);
@@ -865,7 +866,7 @@ class PlainObjectBase : public internal::dense_xpr_base<Derived>::type
                                                                   && (internal::is_same<Index,T>::value)
                                                                   && Base::SizeAtCompileTime!=Dynamic
                                                                   && Base::SizeAtCompileTime!=1
-                                                                  && internal::is_convertible<T, Scalar>::value
+                                                                  && std::is_convertible_v<T, Scalar>
                                                                   && internal::is_same<typename internal::traits<Derived>::XprKind,ArrayXpr>::value,T*>::type* = 0)
     {
       Base::setConstant(val0);

--- a/Eigen/src/Core/ProductEvaluators.h
+++ b/Eigen/src/Core/ProductEvaluators.h
@@ -583,8 +583,8 @@ struct product_evaluator<Product<Lhs, Rhs, LazyProduct>, ProductTag, DenseShape,
   }
 
 protected:
-  typename internal::add_const_on_value_type<LhsNested>::type m_lhs;
-  typename internal::add_const_on_value_type<RhsNested>::type m_rhs;
+  std::add_const_t<LhsNested> m_lhs;
+  std::add_const_t<RhsNested> m_rhs;
   
   LhsEtorType m_lhsImpl;
   RhsEtorType m_rhsImpl;

--- a/Eigen/src/Core/SolveTriangular.h
+++ b/Eigen/src/Core/SolveTriangular.h
@@ -87,7 +87,7 @@ struct triangular_solver_selector<Lhs,Rhs,Side,Mode,NoUnrolling,Dynamic>
 
   static void run(const Lhs& lhs, Rhs& rhs)
   {
-    typename internal::add_const_on_value_type<ActualLhsType>::type actualLhs = LhsProductTraits::extract(lhs);
+    std::add_const_t<ActualLhsType> actualLhs = LhsProductTraits::extract(lhs);
 
     const Index size = lhs.rows();
     const Index othersize = Side==OnTheLeft? rhs.cols() : rhs.rows();

--- a/Eigen/src/Core/arch/AVX/PacketMath.h
+++ b/Eigen/src/Core/arch/AVX/PacketMath.h
@@ -32,10 +32,6 @@ typedef __m256  Packet8f;
 typedef __m256i Packet8i;
 typedef __m256d Packet4d;
 
-template<> struct is_arithmetic<__m256>  { enum { value = true }; };
-template<> struct is_arithmetic<__m256i> { enum { value = true }; };
-template<> struct is_arithmetic<__m256d> { enum { value = true }; };
-
 #define _EIGEN_DECLARE_CONST_Packet8f(NAME,X) \
   const Packet8f p8f_##NAME = pset1<Packet8f>(X)
 

--- a/Eigen/src/Core/arch/AVX512/PacketMath.h
+++ b/Eigen/src/Core/arch/AVX512/PacketMath.h
@@ -32,19 +32,6 @@ typedef __m512 Packet16f;
 typedef __m512i Packet16i;
 typedef __m512d Packet8d;
 
-template <>
-struct is_arithmetic<__m512> {
-  enum { value = true };
-};
-template <>
-struct is_arithmetic<__m512i> {
-  enum { value = true };
-};
-template <>
-struct is_arithmetic<__m512d> {
-  enum { value = true };
-};
-
 template<> struct packet_traits<float>  : default_packet_traits
 {
   typedef Packet16f type;

--- a/Eigen/src/Core/arch/CUDA/Half.h
+++ b/Eigen/src/Core/arch/CUDA/Half.h
@@ -497,7 +497,6 @@ struct random_default_impl<half, false, false>
   }
 };
 
-template<> struct is_arithmetic<half> { enum { value = true }; };
 
 } // end namespace internal
 

--- a/Eigen/src/Core/arch/CUDA/PacketMath.h
+++ b/Eigen/src/Core/arch/CUDA/PacketMath.h
@@ -18,8 +18,6 @@ namespace internal {
 // introduce conflicts between these packet_traits definitions and the ones
 // we'll use on the host side (SSE, AVX, ...)
 #if defined(EIGEN_CUDACC) && defined(EIGEN_USE_GPU)
-template<> struct is_arithmetic<float4>  { enum { value = true }; };
-template<> struct is_arithmetic<double2> { enum { value = true }; };
 
 template<> struct packet_traits<float> : default_packet_traits
 {

--- a/Eigen/src/Core/arch/CUDA/PacketMathHalf.h
+++ b/Eigen/src/Core/arch/CUDA/PacketMathHalf.h
@@ -17,7 +17,6 @@ namespace internal {
 // Most of the following operations require arch >= 3.0
 #if defined(EIGEN_HAS_CUDA_FP16) && defined(EIGEN_CUDACC) && defined(EIGEN_CUDA_ARCH) && EIGEN_CUDA_ARCH >= 300
 
-template<> struct is_arithmetic<half2> { enum { value = true }; };
 
 template<> struct packet_traits<Eigen::half> : default_packet_traits
 {
@@ -350,7 +349,6 @@ typedef struct {
 } Packet16h;
 
 
-template<> struct is_arithmetic<Packet16h> { enum { value = true }; };
 
 template <>
 struct packet_traits<half> : default_packet_traits {
@@ -718,7 +716,6 @@ typedef struct {
 } Packet8h;
 
 
-template<> struct is_arithmetic<Packet8h> { enum { value = true }; };
 
 template <>
 struct packet_traits<Eigen::half> : default_packet_traits {
@@ -977,7 +974,6 @@ typedef struct {
 } Packet4h;
 
 
-template<> struct is_arithmetic<Packet4h> { enum { value = true }; };
 
 template <>
 struct packet_traits<Eigen::half> : default_packet_traits {

--- a/Eigen/src/Core/arch/SSE/PacketMath.h
+++ b/Eigen/src/Core/arch/SSE/PacketMath.h
@@ -57,9 +57,6 @@ typedef __m128i Packet4i;
 typedef __m128d Packet2d;
 #endif
 
-template<> struct is_arithmetic<__m128>  { enum { value = true }; };
-template<> struct is_arithmetic<__m128i> { enum { value = true }; };
-template<> struct is_arithmetic<__m128d> { enum { value = true }; };
 
 #define vec4f_swizzle1(v,p,q,r,s) \
   (_mm_castsi128_ps(_mm_shuffle_epi32( _mm_castps_si128(v), ((s)<<6|(r)<<4|(q)<<2|(p)))))

--- a/Eigen/src/Core/products/GeneralMatrixMatrix.h
+++ b/Eigen/src/Core/products/GeneralMatrixMatrix.h
@@ -9,6 +9,7 @@
 
 #ifndef EIGEN_GENERAL_MATRIX_MATRIX_H
 #define EIGEN_GENERAL_MATRIX_MATRIX_H
+#include <type_traits>
 
 namespace Eigen {
 
@@ -467,8 +468,8 @@ struct generic_product_impl<Lhs,Rhs,DenseShape,DenseShape,GemmProduct>
     if(a_lhs.cols()==0 || a_lhs.rows()==0 || a_rhs.cols()==0)
       return;
 
-    typename internal::add_const_on_value_type<ActualLhsType>::type lhs = LhsBlasTraits::extract(a_lhs);
-    typename internal::add_const_on_value_type<ActualRhsType>::type rhs = RhsBlasTraits::extract(a_rhs);
+    std::add_const_t<ActualLhsType> lhs = LhsBlasTraits::extract(a_lhs);
+    std::add_const_t<ActualRhsType> rhs = RhsBlasTraits::extract(a_rhs);
 
     Scalar actualAlpha = alpha * LhsBlasTraits::extractScalarFactor(a_lhs)
                                * RhsBlasTraits::extractScalarFactor(a_rhs);

--- a/Eigen/src/Core/products/GeneralMatrixMatrixTriangular.h
+++ b/Eigen/src/Core/products/GeneralMatrixMatrixTriangular.h
@@ -9,6 +9,7 @@
 
 #ifndef EIGEN_GENERAL_MATRIX_MATRIX_TRIANGULAR_H
 #define EIGEN_GENERAL_MATRIX_MATRIX_TRIANGULAR_H
+#include <type_traits>
 
 namespace Eigen { 
 
@@ -207,13 +208,13 @@ struct general_product_to_triangular_selector<MatrixType,ProductType,UpLo,true>
     typedef internal::blas_traits<Lhs> LhsBlasTraits;
     typedef typename LhsBlasTraits::DirectLinearAccessType ActualLhs;
     typedef typename internal::remove_all<ActualLhs>::type _ActualLhs;
-    typename internal::add_const_on_value_type<ActualLhs>::type actualLhs = LhsBlasTraits::extract(prod.lhs());
+    std::add_const_t<ActualLhs> actualLhs = LhsBlasTraits::extract(prod.lhs());
     
     typedef typename internal::remove_all<typename ProductType::RhsNested>::type Rhs;
     typedef internal::blas_traits<Rhs> RhsBlasTraits;
     typedef typename RhsBlasTraits::DirectLinearAccessType ActualRhs;
     typedef typename internal::remove_all<ActualRhs>::type _ActualRhs;
-    typename internal::add_const_on_value_type<ActualRhs>::type actualRhs = RhsBlasTraits::extract(prod.rhs());
+    std::add_const_t<ActualRhs> actualRhs = RhsBlasTraits::extract(prod.rhs());
 
     Scalar actualAlpha = alpha * LhsBlasTraits::extractScalarFactor(prod.lhs().derived()) * RhsBlasTraits::extractScalarFactor(prod.rhs().derived());
 
@@ -253,13 +254,13 @@ struct general_product_to_triangular_selector<MatrixType,ProductType,UpLo,false>
     typedef internal::blas_traits<Lhs> LhsBlasTraits;
     typedef typename LhsBlasTraits::DirectLinearAccessType ActualLhs;
     typedef typename internal::remove_all<ActualLhs>::type _ActualLhs;
-    typename internal::add_const_on_value_type<ActualLhs>::type actualLhs = LhsBlasTraits::extract(prod.lhs());
+    std::add_const_t<ActualLhs> actualLhs = LhsBlasTraits::extract(prod.lhs());
     
     typedef typename internal::remove_all<typename ProductType::RhsNested>::type Rhs;
     typedef internal::blas_traits<Rhs> RhsBlasTraits;
     typedef typename RhsBlasTraits::DirectLinearAccessType ActualRhs;
     typedef typename internal::remove_all<ActualRhs>::type _ActualRhs;
-    typename internal::add_const_on_value_type<ActualRhs>::type actualRhs = RhsBlasTraits::extract(prod.rhs());
+    std::add_const_t<ActualRhs> actualRhs = RhsBlasTraits::extract(prod.rhs());
 
     typename ProductType::Scalar actualAlpha = alpha * LhsBlasTraits::extractScalarFactor(prod.lhs().derived()) * RhsBlasTraits::extractScalarFactor(prod.rhs().derived());
 

--- a/Eigen/src/Core/products/SelfadjointMatrixMatrix.h
+++ b/Eigen/src/Core/products/SelfadjointMatrixMatrix.h
@@ -9,6 +9,7 @@
 
 #ifndef EIGEN_SELFADJOINT_MATRIX_MATRIX_H
 #define EIGEN_SELFADJOINT_MATRIX_MATRIX_H
+#include <type_traits>
 
 namespace Eigen { 
 
@@ -487,8 +488,8 @@ struct selfadjoint_product_impl<Lhs,LhsMode,false,Rhs,RhsMode,false>
   {
     eigen_assert(dst.rows()==a_lhs.rows() && dst.cols()==a_rhs.cols());
 
-    typename internal::add_const_on_value_type<ActualLhsType>::type lhs = LhsBlasTraits::extract(a_lhs);
-    typename internal::add_const_on_value_type<ActualRhsType>::type rhs = RhsBlasTraits::extract(a_rhs);
+    std::add_const_t<ActualLhsType> lhs = LhsBlasTraits::extract(a_lhs);
+    std::add_const_t<ActualRhsType> rhs = RhsBlasTraits::extract(a_rhs);
 
     Scalar actualAlpha = alpha * LhsBlasTraits::extractScalarFactor(a_lhs)
                                * RhsBlasTraits::extractScalarFactor(a_rhs);

--- a/Eigen/src/Core/products/SelfadjointMatrixVector.h
+++ b/Eigen/src/Core/products/SelfadjointMatrixVector.h
@@ -9,6 +9,7 @@
 
 #ifndef EIGEN_SELFADJOINT_MATRIX_VECTOR_H
 #define EIGEN_SELFADJOINT_MATRIX_VECTOR_H
+#include <type_traits>
 
 namespace Eigen { 
 
@@ -183,8 +184,8 @@ struct selfadjoint_product_impl<Lhs,LhsMode,false,Rhs,0,true>
     
     eigen_assert(dest.rows()==a_lhs.rows() && dest.cols()==a_rhs.cols());
 
-    typename internal::add_const_on_value_type<ActualLhsType>::type lhs = LhsBlasTraits::extract(a_lhs);
-    typename internal::add_const_on_value_type<ActualRhsType>::type rhs = RhsBlasTraits::extract(a_rhs);
+    std::add_const_t<ActualLhsType> lhs = LhsBlasTraits::extract(a_lhs);
+    std::add_const_t<ActualRhsType> rhs = RhsBlasTraits::extract(a_rhs);
 
     Scalar actualAlpha = alpha * LhsBlasTraits::extractScalarFactor(a_lhs)
                                * RhsBlasTraits::extractScalarFactor(a_rhs);

--- a/Eigen/src/Core/products/SelfadjointProduct.h
+++ b/Eigen/src/Core/products/SelfadjointProduct.h
@@ -56,7 +56,7 @@ struct selfadjoint_product_selector<MatrixType,OtherType,UpLo,true>
     typedef internal::blas_traits<OtherType> OtherBlasTraits;
     typedef typename OtherBlasTraits::DirectLinearAccessType ActualOtherType;
     typedef typename internal::remove_all<ActualOtherType>::type _ActualOtherType;
-    typename internal::add_const_on_value_type<ActualOtherType>::type actualOther = OtherBlasTraits::extract(other.derived());
+    std::add_const_t<ActualOtherType> actualOther = OtherBlasTraits::extract(other.derived());
 
     Scalar actualAlpha = alpha * OtherBlasTraits::extractScalarFactor(other.derived());
 
@@ -88,7 +88,7 @@ struct selfadjoint_product_selector<MatrixType,OtherType,UpLo,false>
     typedef internal::blas_traits<OtherType> OtherBlasTraits;
     typedef typename OtherBlasTraits::DirectLinearAccessType ActualOtherType;
     typedef typename internal::remove_all<ActualOtherType>::type _ActualOtherType;
-    typename internal::add_const_on_value_type<ActualOtherType>::type actualOther = OtherBlasTraits::extract(other.derived());
+    std::add_const_t<ActualOtherType> actualOther = OtherBlasTraits::extract(other.derived());
 
     Scalar actualAlpha = alpha * OtherBlasTraits::extractScalarFactor(other.derived());
 

--- a/Eigen/src/Core/products/SelfadjointRank2Update.h
+++ b/Eigen/src/Core/products/SelfadjointRank2Update.h
@@ -9,6 +9,7 @@
 
 #ifndef EIGEN_SELFADJOINTRANK2UPTADE_H
 #define EIGEN_SELFADJOINTRANK2UPTADE_H
+#include <type_traits>
 
 namespace Eigen { 
 
@@ -63,12 +64,12 @@ EIGEN_DEVICE_FUNC SelfAdjointView<MatrixType,UpLo>& SelfAdjointView<MatrixType,U
   typedef internal::blas_traits<DerivedU> UBlasTraits;
   typedef typename UBlasTraits::DirectLinearAccessType ActualUType;
   typedef typename internal::remove_all<ActualUType>::type _ActualUType;
-  typename internal::add_const_on_value_type<ActualUType>::type actualU = UBlasTraits::extract(u.derived());
+  std::add_const_t<ActualUType> actualU = UBlasTraits::extract(u.derived());
 
   typedef internal::blas_traits<DerivedV> VBlasTraits;
   typedef typename VBlasTraits::DirectLinearAccessType ActualVType;
   typedef typename internal::remove_all<ActualVType>::type _ActualVType;
-  typename internal::add_const_on_value_type<ActualVType>::type actualV = VBlasTraits::extract(v.derived());
+  std::add_const_t<ActualVType> actualV = VBlasTraits::extract(v.derived());
 
   // If MatrixType is row major, then we use the routine for lower triangular in the upper triangular case and
   // vice versa, and take the complex conjugate of all coefficients and vector entries.

--- a/Eigen/src/Core/products/TriangularMatrixMatrix.h
+++ b/Eigen/src/Core/products/TriangularMatrixMatrix.h
@@ -9,6 +9,7 @@
 
 #ifndef EIGEN_TRIANGULAR_MATRIX_MATRIX_H
 #define EIGEN_TRIANGULAR_MATRIX_MATRIX_H
+#include <type_traits>
 
 namespace Eigen { 
 
@@ -411,8 +412,8 @@ struct triangular_product_impl<Mode,LhsIsTriangular,Lhs,false,Rhs,false>
     typedef typename RhsBlasTraits::DirectLinearAccessType ActualRhsType;
     typedef typename internal::remove_all<ActualRhsType>::type ActualRhsTypeCleaned;
     
-    typename internal::add_const_on_value_type<ActualLhsType>::type lhs = LhsBlasTraits::extract(a_lhs);
-    typename internal::add_const_on_value_type<ActualRhsType>::type rhs = RhsBlasTraits::extract(a_rhs);
+    std::add_const_t<ActualLhsType> lhs = LhsBlasTraits::extract(a_lhs);
+    std::add_const_t<ActualRhsType> rhs = RhsBlasTraits::extract(a_rhs);
 
     LhsScalar lhs_alpha = LhsBlasTraits::extractScalarFactor(a_lhs);
     RhsScalar rhs_alpha = RhsBlasTraits::extractScalarFactor(a_rhs);

--- a/Eigen/src/Core/products/TriangularMatrixVector.h
+++ b/Eigen/src/Core/products/TriangularMatrixVector.h
@@ -9,6 +9,7 @@
 
 #ifndef EIGEN_TRIANGULARMATRIXVECTOR_H
 #define EIGEN_TRIANGULARMATRIXVECTOR_H
+#include <type_traits>
 
 namespace Eigen {
 
@@ -218,8 +219,8 @@ template<int Mode> struct trmv_selector<Mode,ColMajor>
     
     typedef Map<Matrix<ResScalar,Dynamic,1>, EIGEN_PLAIN_ENUM_MIN(AlignedMax,internal::packet_traits<ResScalar>::size)> MappedDest;
 
-    typename internal::add_const_on_value_type<ActualLhsType>::type actualLhs = LhsBlasTraits::extract(lhs);
-    typename internal::add_const_on_value_type<ActualRhsType>::type actualRhs = RhsBlasTraits::extract(rhs);
+    std::add_const_t<ActualLhsType> actualLhs = LhsBlasTraits::extract(lhs);
+    std::add_const_t<ActualRhsType> actualRhs = RhsBlasTraits::extract(rhs);
 
     LhsScalar lhs_alpha = LhsBlasTraits::extractScalarFactor(lhs);
     RhsScalar rhs_alpha = RhsBlasTraits::extractScalarFactor(rhs);

--- a/Eigen/src/Core/util/IndexedViewHelper.h
+++ b/Eigen/src/Core/util/IndexedViewHelper.h
@@ -10,6 +10,7 @@
 
 #ifndef EIGEN_INDEXED_VIEW_HELPER_H
 #define EIGEN_INDEXED_VIEW_HELPER_H
+#include <type_traits>
 
 namespace Eigen {
 
@@ -119,7 +120,7 @@ template<> struct get_compile_time_incr<SingleRange> {
 
 // Turn a single index into something that looks like an array (i.e., that exposes a .size(), and operatro[](int) methods)
 template<typename T, int XprSize>
-struct IndexedViewCompatibleType<T,XprSize,std::enable_if_t<internal::is_integral<T>::value>> {
+struct IndexedViewCompatibleType<T,XprSize,std::enable_if_t<std::is_integral_v<T>>> {
   // Here we could simply use Array, but maybe it's less work for the compiler to use
   // a simpler wrapper as SingleRange
   //typedef Eigen::Array<Index,1,1> type;

--- a/Eigen/src/Core/util/IntegralConstant.h
+++ b/Eigen/src/Core/util/IntegralConstant.h
@@ -162,7 +162,7 @@ template<int N> EIGEN_DEVICE_FUNC Index get_runtime_value(FixedInt<N> (*)()) { r
 template<typename T, int DynamicKey=Dynamic, typename EnableIf=void> struct cleanup_index_type { typedef T type; };
 
 // Convert any integral type (e.g., short, int, unsigned int, etc.) to Eigen::Index
-template<typename T, int DynamicKey> struct cleanup_index_type<T,DynamicKey,std::enable_if_t<internal::is_integral<T>::value>> { typedef Index type; };
+template<typename T, int DynamicKey> struct cleanup_index_type<T,DynamicKey,std::enable_if_t<std::is_integral_v<T>>> { typedef Index type; };
 
 #if !EIGEN_HAS_CXX23
 // In pre-c++23 versions, fix<N> was a pointer to function that we better cleanup to a true FixedInt<N>:

--- a/Eigen/src/Core/util/Meta.h
+++ b/Eigen/src/Core/util/Meta.h
@@ -83,36 +83,11 @@ template<typename T> struct remove_all<T&>        { typedef typename remove_all<
 template<typename T> struct remove_all<T const*>  { typedef typename remove_all<T>::type type; };
 template<typename T> struct remove_all<T*>        { typedef typename remove_all<T>::type type; };
 
-template<typename T> struct is_arithmetic      { enum { value = false }; };
-template<> struct is_arithmetic<float>         { enum { value = true }; };
-template<> struct is_arithmetic<double>        { enum { value = true }; };
-template<> struct is_arithmetic<long double>   { enum { value = true }; };
-template<> struct is_arithmetic<bool>          { enum { value = true }; };
-template<> struct is_arithmetic<char>          { enum { value = true }; };
-template<> struct is_arithmetic<signed char>   { enum { value = true }; };
-template<> struct is_arithmetic<unsigned char> { enum { value = true }; };
-template<> struct is_arithmetic<signed short>  { enum { value = true }; };
-template<> struct is_arithmetic<unsigned short>{ enum { value = true }; };
-template<> struct is_arithmetic<signed int>    { enum { value = true }; };
-template<> struct is_arithmetic<unsigned int>  { enum { value = true }; };
-template<> struct is_arithmetic<signed long>   { enum { value = true }; };
-template<> struct is_arithmetic<unsigned long> { enum { value = true }; };
+template <typename T>
+using is_arithmetic = std::is_arithmetic<T>;
 
-#if EIGEN_HAS_CXX23
-using std::is_integral;
-#else
-template<typename T> struct is_integral               { enum { value = false }; };
-template<> struct is_integral<bool>                   { enum { value = true }; };
-template<> struct is_integral<char>                   { enum { value = true }; };
-template<> struct is_integral<signed char>            { enum { value = true }; };
-template<> struct is_integral<unsigned char>          { enum { value = true }; };
-template<> struct is_integral<signed short>           { enum { value = true }; };
-template<> struct is_integral<unsigned short>         { enum { value = true }; };
-template<> struct is_integral<signed int>             { enum { value = true }; };
-template<> struct is_integral<unsigned int>           { enum { value = true }; };
-template<> struct is_integral<signed long>            { enum { value = true }; };
-template<> struct is_integral<unsigned long>          { enum { value = true }; };
-#endif
+template <typename T>
+using is_integral = std::is_integral<T>;
 
 
 template <typename T> struct add_const { typedef const T type; };
@@ -121,46 +96,12 @@ template <typename T> struct add_const<T&> { typedef T& type; };
 template <typename T> struct is_const { enum { value = 0 }; };
 template <typename T> struct is_const<T const> { enum { value = 1 }; };
 
-template<typename T> struct add_const_on_value_type            { typedef const T type;  };
-template<typename T> struct add_const_on_value_type<T&>        { typedef T const& type; };
-template<typename T> struct add_const_on_value_type<T*>        { typedef T const* type; };
-template<typename T> struct add_const_on_value_type<T* const>  { typedef T const* const type; };
-template<typename T> struct add_const_on_value_type<T const* const>  { typedef T const* const type; };
+template <typename T>
+using add_const_on_value_type = std::add_const_t<T>;
 
 
-template<typename From, typename To>
-struct is_convertible_impl
-{
-private:
-  struct any_conversion
-  {
-    template <typename T> any_conversion(const volatile T&);
-    template <typename T> any_conversion(T&);
-  };
-  struct yes {int a[1];};
-  struct no  {int a[2];};
-
-  static yes test(const To&, int);
-  static no  test(any_conversion, ...);
-
-public:
-  static From ms_from;
-#ifdef __INTEL_COMPILER
-  #pragma warning push
-  #pragma warning ( disable : 2259 )
-#endif
-  enum { value = sizeof(test(ms_from, 0))==sizeof(yes) };
-#ifdef __INTEL_COMPILER
-  #pragma warning pop
-#endif
-};
-
-template<typename From, typename To>
-struct is_convertible
-{
-  enum { value = is_convertible_impl<typename remove_all<From>::type,
-                                     typename remove_all<To  >::type>::value };
-};
+template <typename From, typename To>
+constexpr bool is_convertible = std::is_convertible_v<From, To>;
 
 /** \internal Allows to enable/disable an overload
   * according to a compile time condition.

--- a/Eigen/src/Core/util/SymbolicIndex.h
+++ b/Eigen/src/Core/util/SymbolicIndex.h
@@ -9,6 +9,7 @@
 
 #ifndef EIGEN_SYMBOLIC_INDEX_H
 #define EIGEN_SYMBOLIC_INDEX_H
+#include <type_traits>
 
 namespace Eigen {
 
@@ -188,7 +189,7 @@ public:
 template<typename T>
 struct is_symbolic {
   // BaseExpr has no conversion ctor, so we only have to check whether T can be staticaly cast to its base class BaseExpr<T>.
-  enum { value = internal::is_convertible<T,BaseExpr<T> >::value };
+  enum { value = std::is_convertible_v<T,BaseExpr<T>> };
 };
 
 // Specialization for functions, because is_convertible fails in this case.

--- a/Eigen/src/Core/util/XprHelper.h
+++ b/Eigen/src/Core/util/XprHelper.h
@@ -39,10 +39,10 @@ template<typename T> struct is_valid_index_type
 {
   enum { value =
 #if EIGEN_HAS_TYPE_TRAITS
-   internal::is_integral<T>::value || std::is_enum<T>::value
+   std::is_integral_v<T> || std::is_enum<T>::value
 #else
-  // without C++23, we use is_convertible to Index instead of is_integral in order to treat enums as Index.
-  internal::is_convertible<T,Index>::value
+  // without C++23, we use std::is_convertible to Index instead of is_integral in order to treat enums as Index.
+  std::is_convertible_v<T,Index>
 #endif
   };
 };
@@ -67,7 +67,7 @@ struct promote_scalar_arg<S,T,true>
 
 // Recursively check safe conversion to PromotedType, and then ExprScalar if they are different.
 template<typename ExprScalar,typename T,typename PromotedType,
-  bool ConvertibleToLiteral = internal::is_convertible<T,PromotedType>::value,
+  bool ConvertibleToLiteral = std::is_convertible_v<T,PromotedType>,
   bool IsSafe = NumTraits<T>::IsInteger || !NumTraits<PromotedType>::IsInteger>
 struct promote_scalar_arg_unsupported;
 
@@ -428,7 +428,7 @@ struct transfer_constness
 {
   typedef typename conditional<
     bool(internal::is_const<T1>::value),
-    typename internal::add_const_on_value_type<T2>::type,
+    std::add_const_t<T2>,
     T2
   >::type type;
 };

--- a/Eigen/src/Eigenvalues/Tridiagonalization.h
+++ b/Eigen/src/Eigenvalues/Tridiagonalization.h
@@ -86,12 +86,12 @@ template<typename _MatrixType> class Tridiagonalization
     typedef internal::TridiagonalizationMatrixTReturnType<MatrixTypeRealView> MatrixTReturnType;
 
     typedef typename internal::conditional<NumTraits<Scalar>::IsComplex,
-              typename internal::add_const_on_value_type<typename Diagonal<const MatrixType>::RealReturnType>::type,
+              std::add_const_t<typename Diagonal<const MatrixType>::RealReturnType>,
               const Diagonal<const MatrixType>
             >::type DiagonalReturnType;
 
     typedef typename internal::conditional<NumTraits<Scalar>::IsComplex,
-              typename internal::add_const_on_value_type<typename Diagonal<const MatrixType, -1>::RealReturnType>::type,
+              std::add_const_t<typename Diagonal<const MatrixType, -1>::RealReturnType>,
               const Diagonal<const MatrixType, -1>
             >::type SubDiagonalReturnType;
 

--- a/Eigen/src/StlSupport/details.h
+++ b/Eigen/src/StlSupport/details.h
@@ -10,6 +10,7 @@
 
 #ifndef EIGEN_STL_DETAILS_H
 #define EIGEN_STL_DETAILS_H
+#include <type_traits>
 
 #ifndef EIGEN_ALIGNED_ALLOCATOR
   #define EIGEN_ALIGNED_ALLOCATOR Eigen::aligned_allocator
@@ -53,7 +54,7 @@ namespace Eigen {
   // even if this function is never called. Whence this little wrapper.
 #define EIGEN_WORKAROUND_MSVC_STL_SUPPORT(T) \
   typename Eigen::internal::conditional< \
-    Eigen::internal::is_arithmetic<T>::value, \
+    std::is_arithmetic_v<T>, \
     T, \
     Eigen::internal::workaround_msvc_stl_support<T> \
   >::type

--- a/test/main.h
+++ b/test/main.h
@@ -493,7 +493,7 @@ typename T1::RealScalar test_relative_error(const SparseMatrixBase<T1> &a, const
 }
 
 template<typename T1,typename T2>
-typename NumTraits<typename NumTraits<T1>::Real>::NonInteger test_relative_error(const T1 &a, const T2 &b, typename internal::enable_if<internal::is_arithmetic<typename NumTraits<T1>::Real>::value, T1>::type* = 0)
+typename NumTraits<typename NumTraits<T1>::Real>::NonInteger test_relative_error(const T1 &a, const T2 &b, std::enable_if_t<std::is_arithmetic_v<typename NumTraits<T1>::Real>, T1>* = 0)
 {
   typedef typename NumTraits<typename NumTraits<T1>::Real>::NonInteger RealScalar;
   return numext::sqrt(RealScalar(numext::abs2(a-b))/RealScalar((numext::mini)(numext::abs2(a),numext::abs2(b))));
@@ -525,7 +525,7 @@ typename NumTraits<typename T::Scalar>::Real get_test_precision(const T&, const 
 }
 
 template<typename T>
-typename NumTraits<T>::Real get_test_precision(const T&,typename internal::enable_if<internal::is_arithmetic<typename NumTraits<T>::Real>::value, T>::type* = 0)
+typename NumTraits<T>::Real get_test_precision(const T&,std::enable_if_t<std::is_arithmetic_v<typename NumTraits<T>::Real>, T>* = 0)
 {
   return test_precision<typename NumTraits<T>::Real>();
 }

--- a/test/meta.cpp
+++ b/test/meta.cpp
@@ -12,7 +12,7 @@
 template<typename From, typename To>
 bool check_is_convertible(const From&, const To&)
 {
-  return internal::is_convertible<From,To>::value;
+  return std::is_convertible_v<From, To>;
 }
 
 struct FooReturnType {
@@ -47,14 +47,14 @@ void test_meta()
   VERIFY(( internal::is_same< internal::remove_const<float* const>::type, float* >::value));
 
   // test add_const_on_value_type
-  VERIFY(( internal::is_same< internal::add_const_on_value_type<float&>::type, float const& >::value));
-  VERIFY(( internal::is_same< internal::add_const_on_value_type<float*>::type, float const* >::value));
+  VERIFY(( internal::is_same< std::add_const_t<float&>, float const& >::value));
+  VERIFY(( internal::is_same< std::add_const_t<float*>, float const* >::value));
 
-  VERIFY(( internal::is_same< internal::add_const_on_value_type<float>::type, const float >::value));
-  VERIFY(( internal::is_same< internal::add_const_on_value_type<const float>::type, const float >::value));
+  VERIFY(( internal::is_same< std::add_const_t<float>, const float >::value));
+  VERIFY(( internal::is_same< std::add_const_t<const float>, const float >::value));
 
-  VERIFY(( internal::is_same< internal::add_const_on_value_type<const float* const>::type, const float* const>::value));
-  VERIFY(( internal::is_same< internal::add_const_on_value_type<float* const>::type, const float* const>::value));
+  VERIFY(( internal::is_same< std::add_const_t<const float* const>, const float* const>::value));
+  VERIFY(( internal::is_same< std::add_const_t<float* const>, const float* const>::value));
   
   VERIFY(( internal::is_same<float,internal::remove_reference<float&>::type >::value));
   VERIFY(( internal::is_same<const float,internal::remove_reference<const float&>::type >::value));
@@ -62,14 +62,14 @@ void test_meta()
   VERIFY(( internal::is_same<const float,internal::remove_pointer<const float*>::type >::value));
   VERIFY(( internal::is_same<float,internal::remove_pointer<float* const >::type >::value));
   
-  VERIFY(( internal::is_convertible<float,double>::value ));
-  VERIFY(( internal::is_convertible<int,double>::value ));
-  VERIFY(( internal::is_convertible<double,int>::value ));
-  VERIFY((!internal::is_convertible<std::complex<double>,double>::value ));
-  VERIFY(( internal::is_convertible<Array33f,Matrix3f>::value ));
+  VERIFY(( std::is_convertible_v<float,double> ));
+  VERIFY(( std::is_convertible_v<int,double> ));
+  VERIFY(( std::is_convertible_v<double,int> ));
+  VERIFY((!std::is_convertible_v<std::complex<double>,double> ));
+  VERIFY(( std::is_convertible_v<Array33f,Matrix3f> ));
 //   VERIFY((!internal::is_convertible<Matrix3f,Matrix3d>::value )); //does not work because the conversion is prevented by a static assertion
-  VERIFY((!internal::is_convertible<Array33f,int>::value ));
-  VERIFY((!internal::is_convertible<MatrixXf,float>::value ));
+  VERIFY((!std::is_convertible_v<Array33f,int> ));
+  VERIFY((!std::is_convertible_v<MatrixXf,float> ));
   {
     float f;
     MatrixXf A, B;

--- a/unsupported/Eigen/src/AutoDiff/AutoDiffScalar.h
+++ b/unsupported/Eigen/src/AutoDiff/AutoDiffScalar.h
@@ -116,7 +116,7 @@ class AutoDiffScalar
         std::enable_if_t<
             internal::is_same<Scalar, typename internal::traits<typename internal::remove_all<
                                           OtherDerType>>::Scalar>::value &&
-                internal::is_convertible<OtherDerType, DerType>::value,
+                std::is_convertible_v<OtherDerType, DerType>,
             void *>::type = 0
 #endif
         )


### PR DESCRIPTION
## Summary
- use `std::is_arithmetic` and `std::is_integral`
- replace custom const helpers with `std::add_const_t`
- rely on `std::is_convertible_v` instead of bespoke metafunction
- clean up packet trait specializations
- adjust tests and includes for new traits

## Testing
- `pre-commit` *(fails: command not found)*