### PR TITLE
Update docs to reflect C++23 modernization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,9 @@
-# Eigen \u2192 EigenC Port
+# Eigen Modernisation Plan
 
-Below is a cook-book\u2013style "run-sheet" you can hand to Codex (or adapt in a GUI session) that will drive a fully offline, reproducible translation of this Eigen fork into **EigenC** \u2013 a pure C23, header-only linear-algebra layer mimicking Eigen's public API.
+This repository is being refactored to **C++23** while simultaneously providing
+experimental C23 and Go frontends. The notes below outline how Codex can assist
+with generating the C23 interface ("EigenC") and the Go bindings. All build
+scripts and makefiles are gradually updated to support these variants.
 
 Codex is brilliant at static reasoning over the tree of files it can see. Install every external tool it might invoke during the setup window; afterwards it is hermetically sealed. Eigen itself is already header-only, but its C++ machinery (expression templates, meta-programming) must be reified into C23's `_Generic`, `static inline`, and macro metaprogramming.
 
@@ -23,10 +26,11 @@ Make sure `setup.sh` is executable (`chmod +x`). Commit nothing that you expect 
 ## 1  AGENTS.md \u2014 tell Codex what to do
 
 ### Goal
-Produce `eigenc/` \u2013 a header-only C23 linear-algebra library that:
-* Preserves Eigen's user-facing API where C syntax allows
-* Passes a subset of Eigen's test-suite compiled as pure C (see tests/)
-* Achieves within 3 % numerical parity for float32/float64
+Modernise Eigen to C++23 and provide experimental `eigenc/` and `eigengo/`
+frontends:
+* Keep the C++ API compatible while adopting modern language features.
+* Generate a header-only C23 layer mirroring Eigen's API where C allows.
+* Offer Go bindings that call into the generated C layer.
 
 ### Road-map
 1. Build a **template-to-C23 translation pipeline** using Clang libTooling

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# EigenC: Bridging Eigen to C23
+# Eigen Modernisation and Experimental C/Go Frontends
 
-This fork tracks an effort to translate the Eigen C++ library into a set of
-headers that can be consumed from pure C23.  The goal is to retain the familiar
-API while generating self contained C code that does not depend on C++
-features.
+This fork modernises the Eigen codebase to **C++23** while also providing
+experimental frontends for **C23** and **Go**. The traditional C++ headers are
+kept in `Eigen/` and gradually updated to the new standard.  In parallel the
+C23 interface ("EigenC") is generated under `eigenc/` and a Go module lives in
+`go/`. Makefiles and CMake scripts are being updated to accommodate all three
+variants.
 
 The translation process lives in `porter/` and outputs headers under
 `eigenc/include`.  These C headers implement basic matrix operations with

--- a/porter/README.md
+++ b/porter/README.md
@@ -1,7 +1,7 @@
 # Porter Tools
 
-The `porter/` directory contains helper scripts for translating Eigen's C++
-templates into a small C23 and Go interface.
+The `porter/` directory contains helper scripts for generating the experimental
+C23 and Go frontends from Eigen's modernised C++23 headers.
 
 * `scan_templates.py` – walk the `Eigen/` headers and collect template
   instantiations. ASTs are written to `porter/asts/` and the discovered


### PR DESCRIPTION
## Summary
- clarify modernisation to C++23 and mention experimental C23/Go efforts in README
- describe experimental frontends in `porter/README.md`
- update `AGENTS.md` to match the new development plan

## Testing
- `bash tests/run_all.sh`