### PR TITLE
Add matrix multiplication in Go EC bindings

### DIFF
--- a/go/ec/ec.go
+++ b/go/ec/ec.go
@@ -3,6 +3,22 @@ package ec
 /*
 #cgo CFLAGS: -std=c2x -I${SRCDIR}/../../eigenc/include
 #include "ec_core.h"
+typedef struct {
+    size_t rows;
+    size_t cols;
+    double *data;
+} EC_Matrix2d;
+static inline void EC_Matrix2d_mul(const EC_Matrix2d *a, const EC_Matrix2d *b, EC_Matrix2d *out) {
+    assert(a->cols == b->rows && a->rows == out->rows && b->cols == out->cols);
+    for (size_t i = 0; i < a->rows; ++i) {
+        for (size_t j = 0; j < b->cols; ++j) {
+            double sum = 0;
+            for (size_t k = 0; k < a->cols; ++k)
+                sum += a->data[i * a->cols + k] * b->data[k * b->cols + j];
+            out->data[i * out->cols + j] = sum;
+        }
+    }
+}
 */
 import "C"
 import "unsafe"
@@ -97,6 +113,72 @@ func AddF64(a, b MatrixF64) MatrixF64 {
 
 	out := MatrixF64{Rows: a.Rows, Cols: a.Cols, Data: make([]float64, n)}
 	cSlice := (*[1 << 30]C.double)(unsafe.Pointer(pc))[:n:n]
+	for i := 0; i < n; i++ {
+		out.Data[i] = float64(cSlice[i])
+	}
+	return out
+}
+
+// MulF32 multiplies two 2x2 float32 matrices using EigenC.
+func MulF32(a, b MatrixF32) MatrixF32 {
+	if a.Rows != 2 || a.Cols != 2 || b.Rows != 2 || b.Cols != 2 {
+		panic("MulF32 expects 2x2 matrices")
+	}
+	n := 4
+	pa := (*C.float)(C.malloc(C.size_t(n) * C.size_t(C.sizeof_float)))
+	pb := (*C.float)(C.malloc(C.size_t(n) * C.size_t(C.sizeof_float)))
+	pc := (*C.float)(C.malloc(C.size_t(n) * C.size_t(C.sizeof_float)))
+	defer C.free(unsafe.Pointer(pa))
+	defer C.free(unsafe.Pointer(pb))
+	defer C.free(unsafe.Pointer(pc))
+
+	aSlice := (*[4]C.float)(unsafe.Pointer(pa))[:]
+	bSlice := (*[4]C.float)(unsafe.Pointer(pb))[:]
+	for i := 0; i < n; i++ {
+		aSlice[i] = C.float(a.Data[i])
+		bSlice[i] = C.float(b.Data[i])
+	}
+
+	ca := C.EC_Matrix2f{rows: 2, cols: 2, data: pa}
+	cb := C.EC_Matrix2f{rows: 2, cols: 2, data: pb}
+	co := C.EC_Matrix2f{rows: 2, cols: 2, data: pc}
+	C.EC_Matrix2f_mul(&ca, &cb, &co)
+
+	out := MatrixF32{Rows: 2, Cols: 2, Data: make([]float32, n)}
+	cSlice := (*[4]C.float)(unsafe.Pointer(pc))[:]
+	for i := 0; i < n; i++ {
+		out.Data[i] = float32(cSlice[i])
+	}
+	return out
+}
+
+// MulF64 multiplies two 2x2 float64 matrices using EigenC.
+func MulF64(a, b MatrixF64) MatrixF64 {
+	if a.Rows != 2 || a.Cols != 2 || b.Rows != 2 || b.Cols != 2 {
+		panic("MulF64 expects 2x2 matrices")
+	}
+	n := 4
+	pa := (*C.double)(C.malloc(C.size_t(n) * C.size_t(C.sizeof_double)))
+	pb := (*C.double)(C.malloc(C.size_t(n) * C.size_t(C.sizeof_double)))
+	pc := (*C.double)(C.malloc(C.size_t(n) * C.size_t(C.sizeof_double)))
+	defer C.free(unsafe.Pointer(pa))
+	defer C.free(unsafe.Pointer(pb))
+	defer C.free(unsafe.Pointer(pc))
+
+	aSlice := (*[4]C.double)(unsafe.Pointer(pa))[:]
+	bSlice := (*[4]C.double)(unsafe.Pointer(pb))[:]
+	for i := 0; i < n; i++ {
+		aSlice[i] = C.double(a.Data[i])
+		bSlice[i] = C.double(b.Data[i])
+	}
+
+	ca := C.EC_Matrix2d{rows: 2, cols: 2, data: pa}
+	cb := C.EC_Matrix2d{rows: 2, cols: 2, data: pb}
+	co := C.EC_Matrix2d{rows: 2, cols: 2, data: pc}
+	C.EC_Matrix2d_mul(&ca, &cb, &co)
+
+	out := MatrixF64{Rows: 2, Cols: 2, Data: make([]float64, n)}
+	cSlice := (*[4]C.double)(unsafe.Pointer(pc))[:]
 	for i := 0; i < n; i++ {
 		out.Data[i] = float64(cSlice[i])
 	}

--- a/go/ec/ec_test.go
+++ b/go/ec/ec_test.go
@@ -25,3 +25,27 @@ func TestAddF64(t *testing.T) {
 		}
 	}
 }
+
+func TestMulF32(t *testing.T) {
+	a := MatrixF32{Rows: 2, Cols: 2, Data: []float32{1, 2, 3, 4}}
+	b := MatrixF32{Rows: 2, Cols: 2, Data: []float32{5, 6, 7, 8}}
+	c := MulF32(a, b)
+	expected := []float32{19, 22, 43, 50}
+	for i, v := range expected {
+		if c.Data[i] != v {
+			t.Fatalf("c[%d] = %f, want %f", i, c.Data[i], v)
+		}
+	}
+}
+
+func TestMulF64(t *testing.T) {
+	a := MatrixF64{Rows: 2, Cols: 2, Data: []float64{1, 2, 3, 4}}
+	b := MatrixF64{Rows: 2, Cols: 2, Data: []float64{5, 6, 7, 8}}
+	c := MulF64(a, b)
+	expected := []float64{19, 22, 43, 50}
+	for i, v := range expected {
+		if c.Data[i] != v {
+			t.Fatalf("c[%d] = %f, want %f", i, c.Data[i], v)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- extend EC Go bindings with MulF32 and MulF64 using EC_Matrix2f_mul and EC_Matrix2d_mul
- implement EC_Matrix2d structures in the cgo preamble
- test multiplication for float32 and float64

## Testing
- `go test ./...`