### PR TITLE
Add gofmt and black hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,14 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+        language_version: python3
+        files: "^(porter/|tests/).*\\.py$"
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v1.5.0
+    hooks:
+      - id: gofmt
+        files: "^go/.*\\.go$"

--- a/setup.sh
+++ b/setup.sh
@@ -85,7 +85,7 @@ done
 pip_install clang==17.*
 
 # Ensure key Python tooling is installed via pip
-pip_install pre-commit configuredb pytest PyYAML pylint pyfuzz
+pip_install pre-commit configuredb pytest PyYAML pylint pyfuzz black
 
 # Install pre-commit hooks while network is available
 if ! pre-commit install --install-hooks; then
@@ -192,7 +192,7 @@ command -v clang-tidy >/dev/null 2>&1 || ln -s "$(command -v clang-tidy-17)" /us
 command -v clang-format >/dev/null 2>&1 || ln -s "$(command -v clang-format-17)" /usr/local/bin/clang-format
 
 # Verify key Python tooling availability
-for tool in pre-commit configuredb pytest pyyaml pylint pyfuzz; do
+for tool in pre-commit configuredb pytest pyyaml pylint pyfuzz black; do
   if ! "$tool" --version >/dev/null 2>&1; then
     echo "$tool --version failed" >> "$FAIL_LOG"
   fi


### PR DESCRIPTION
## Summary
- run `black` on porter/ and tests/ directories
- run `gofmt` on files under `go/`
- install the required tools in setup

## Testing
- `bash tests/run_all.sh` *(fails: gcc doesn't recognize -std=c23)*
- `pre-commit --version` *(fails: command not found)*