### PR TITLE
Improve SpinLock with cross-platform backoff

### DIFF
--- a/tests/spinlock/test_spinlock.cpp
+++ b/tests/spinlock/test_spinlock.cpp
@@ -11,9 +11,8 @@ int main() {
     for(int i = 0; i < 4; ++i) {
         threads.emplace_back([&]() {
             for(int j = 0; j < loops; ++j) {
-                lock.lock();
+                Eigen::cxx23::SpinLockGuard g(lock);
                 ++counter;
-                lock.unlock();
             }
         });
     }

--- a/unsupported/Eigen/CXX23/src/SpinLock.h
+++ b/unsupported/Eigen/CXX23/src/SpinLock.h
@@ -3,20 +3,44 @@
 
 #include <atomic>
 #include <thread>
+#include <new>
+#if defined(__x86_64__) || defined(__i386__)
+#  include <immintrin.h>
+#endif
 
 namespace Eigen {
 namespace cxx23 {
 
+namespace detail {
+  inline void cpu_relax() noexcept {
+#if defined(__x86_64__) || defined(__i386__)
+    _mm_pause();
+#elif defined(__aarch64__) || defined(__arm__)
+    __asm__ __volatile__("yield");
+#elif defined(__riscv)
+    __asm__ __volatile__("pause");
+#else
+    std::this_thread::yield();
+#endif
+  }
+}
+
 class SpinLock {
-  std::atomic_flag flag = ATOMIC_FLAG_INIT;
+  alignas(std::hardware_destructive_interference_size) std::atomic_flag flag = ATOMIC_FLAG_INIT;
 public:
   constexpr SpinLock() noexcept = default;
   SpinLock(const SpinLock&) = delete;
   SpinLock& operator=(const SpinLock&) = delete;
 
   void lock() noexcept {
+    std::size_t spin = 0;
     while(flag.test_and_set(std::memory_order_acquire)) {
-      std::this_thread::yield();
+      if(spin < 16) {
+        detail::cpu_relax();
+        ++spin;
+      } else {
+        std::this_thread::yield();
+      }
     }
   }
 
@@ -27,6 +51,15 @@ public:
   void unlock() noexcept {
     flag.clear(std::memory_order_release);
   }
+};
+
+class SpinLockGuard {
+  SpinLock& lock_;
+public:
+  explicit SpinLockGuard(SpinLock& l) noexcept : lock_(l) { lock_.lock(); }
+  ~SpinLockGuard() { lock_.unlock(); }
+  SpinLockGuard(const SpinLockGuard&) = delete;
+  SpinLockGuard& operator=(const SpinLockGuard&) = delete;
 };
 
 } // namespace cxx23


### PR DESCRIPTION
## Summary
- upgrade the experimental SpinLock implementation
  - align to cacheline
  - add portable CPU relax helper with architecture-specific instructions
  - add exponential backoff in `lock()`
  - provide new `SpinLockGuard` for RAII usage
- adjust spinlock test to use the new guard

## Testing
- `bash tests/run_all.sh`