### PR TITLE
Clarify LAPACK addons handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,5 +118,14 @@ Then execute the helper script which runs clang-tidy across the tree:
 ../scripts/run-clang-tidy.sh
 ```
 
+### LAPACK Addons for Unit Tests
+
+To run the optional LAPACK unit tests enable the CMake option
+`EIGEN_ENABLE_LAPACK_TESTS`. The build expects the archive
+`lapack_addons_3.4.1.tgz` to be available in the `lapack/` directory.
+Place the file manually or have your environment setup fetch it during
+`setup.sh` execution. When network access is unavailable you must copy
+the archive to that location before configuring the build.
+
 
 

--- a/lapack/CMakeLists.txt
+++ b/lapack/CMakeLists.txt
@@ -35,34 +35,35 @@ set(EigenLapack_SRCS  ${EigenLapack_SRCS}
   second_NONE.f dsecnd_NONE.f
 )
 
-option(EIGEN_ENABLE_LAPACK_TESTS OFF "Enbale the Lapack unit tests")
+option(EIGEN_ENABLE_LAPACK_TESTS OFF "Enable the Lapack unit tests")
+option(EIGEN_DOWNLOAD_LAPACK_ADDONS OFF "Download lapack_addons_3.4.1.tgz if missing (requires network)")
 
 if(EIGEN_ENABLE_LAPACK_TESTS)
+  # The reference LAPACK sources come from lapack_addons_3.4.1.tgz.
+  # Place this archive in the lapack/ directory or enable
+  # EIGEN_DOWNLOAD_LAPACK_ADDONS to fetch it automatically.
 
   get_filename_component(eigen_full_path_to_reference_lapack "./reference/" ABSOLUTE)
   if(NOT EXISTS ${eigen_full_path_to_reference_lapack})
-    # Download lapack and install sources and testing at the right place
-    message(STATUS "Download lapack_addons_3.4.1.tgz...")
-    
-    file(DOWNLOAD "http://downloads.tuxfamily.org/eigen/lapack_addons_3.4.1.tgz"
-                  "${CMAKE_CURRENT_SOURCE_DIR}/lapack_addons_3.4.1.tgz"
-                  INACTIVITY_TIMEOUT 15
-                  TIMEOUT 240
-                  STATUS download_status
-                  EXPECTED_MD5 5758ce55afcf79da98de8b9de1615ad5
-                  SHOW_PROGRESS)
-                  
-    message(STATUS ${download_status})
-    list(GET download_status 0 download_status_num)
-    set(download_status_num 0)
-    if(download_status_num EQUAL 0)
-      message(STATUS "Setup lapack reference and lapack unit tests")
-      execute_process(COMMAND tar xzf  "lapack_addons_3.4.1.tgz" WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-    else()
-      message(STATUS "Download of lapack_addons_3.4.1.tgz failed, LAPACK unit tests wont be enabled")
-      set(EIGEN_ENABLE_LAPACK_TESTS false)
+    if(EIGEN_DOWNLOAD_LAPACK_ADDONS)
+      message(STATUS "Download lapack_addons_3.4.1.tgz...")
+      file(DOWNLOAD "http://downloads.tuxfamily.org/eigen/lapack_addons_3.4.1.tgz"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/lapack_addons_3.4.1.tgz"
+                    INACTIVITY_TIMEOUT 15
+                    TIMEOUT 240
+                    STATUS download_status
+                    EXPECTED_MD5 5758ce55afcf79da98de8b9de1615ad5
+                    SHOW_PROGRESS)
+      message(STATUS ${download_status})
+      list(GET download_status 0 download_status_num)
+      if(download_status_num EQUAL 0)
+        message(STATUS "Setup lapack reference and lapack unit tests")
+        execute_process(COMMAND tar xzf "lapack_addons_3.4.1.tgz" WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+      else()
+        message(STATUS "Download of lapack_addons_3.4.1.tgz failed, LAPACK unit tests wont be enabled")
+        set(EIGEN_ENABLE_LAPACK_TESTS false)
+      endif()
     endif()
-                  
   endif()
   
   get_filename_component(eigen_full_path_to_reference_lapack "./reference/" ABSOLUTE)

--- a/setup.sh
+++ b/setup.sh
@@ -63,6 +63,7 @@ for pkg in \
   autoconf automake libtool m4 gawk flex bison byacc \
   pkg-config file ca-certificates curl git unzip \
   libopenblas-dev liblapack-dev libeigen3-dev \
+  # lapack_addons_3.4.1.tgz must be placed in lapack/ when enabling LAPACK tests
   strace ltrace linux-perf systemtap systemtap-sdt-dev crash \
   valgrind kcachegrind trace-cmd kernelshark \
   libasan6 libubsan1 likwid hwloc; do


### PR DESCRIPTION
## Summary
- guard the lapack addons download behind `EIGEN_DOWNLOAD_LAPACK_ADDONS`
- document how to manually place `lapack_addons_3.4.1.tgz`
- note the archive in `setup.sh`

## Testing
- `bash tests/run_all.sh`

------
https://chatgpt.com/codex/tasks/task_e_683bc08c86708331996964756d8dec11