### PR TITLE
Fix cmake version declaration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,11 @@
+# Require modern CMake before defining the project
+cmake_minimum_required(VERSION 3.20)
+
 project(Eigen3)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-cmake_minimum_required(VERSION 2.8.5)
 
 # guard against in-source builds
 


### PR DESCRIPTION
## Summary
- move minimum CMake version requirement to the top
- require CMake 3.20

## Testing
- `cmake --log-level=ERROR -Wno-dev -S . -B build -DBLA_VENDOR=Generic`

------
https://chatgpt.com/codex/tasks/task_e_683bc02f04448331a29390deee44ec89